### PR TITLE
chore: Update examples to .NET 8

### DIFF
--- a/console/ConsoleSample.csproj
+++ b/console/ConsoleSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docker-agent-installed/alpine/Dockerfile
+++ b/docker-agent-installed/alpine/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
 WORKDIR /app
 EXPOSE 80
 ENV ASPNETCORE_URLS=http://+:80
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build 
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 
 WORKDIR /src
 COPY . ./
@@ -17,10 +17,10 @@ FROM base AS final
 # To use a specific version instead, modify the wget and tar commands to reference the full path to the 
 # dotnet agent version tarball you want to use instead of the wildcard specification
 # 
-# For example, to use v10.17.0 of the .NET agent, you would run the following command:
+# For example, to use v10.21.1 of the .NET agent, you would run the following command:
 # RUN apk update && apk add --no-cache wget tar \
-#     && wget https://download.newrelic.com/dot_net_agent/previous_releases/10.17.0/newrelic-dotnet-agent-10.17.0.amd64.tar.gz \
-#     && tar -xzf -i download.newrelic.com/dot_net_agent/previous_releases/10.17.0/newrelic-dotnet-agent-10.17.0.amd64.tar.gz -C /usr/local \
+#     && wget https://download.newrelic.com/dot_net_agent/previous_releases/10.21.1/newrelic-dotnet-agent-10.21.1.amd64.tar.gz \
+#     && tar -xzf -i download.newrelic.com/dot_net_agent/previous_releases/10.21.1/newrelic-dotnet-agent-10.21.1.amd64.tar.gz -C /usr/local \
 #     && rm -rf download.newrelic.com
 # 
 # the agent is installed at /usr/local/new-relic-dotnet-agent

--- a/docker-agent-installed/alpine/WeatherForecast.csproj
+++ b/docker-agent-installed/alpine/WeatherForecast.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docker-agent-installed/centos/Dockerfile
+++ b/docker-agent-installed/centos/Dockerfile
@@ -4,7 +4,7 @@ EXPOSE 80
 ENV ASPNETCORE_URLS=http://+:80
 
 # build using the Debian-based .NET SDK image
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build 
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /src
 COPY . ./
@@ -14,7 +14,7 @@ RUN dotnet publish -c Release -o /app/publish
 FROM base AS final
 
 # install asp.netcore
-RUN dnf install aspnetcore-runtime-7.0 -y
+RUN dnf install aspnetcore-runtime-8.0 -y
 
 # install wget
 RUN yum -y update && yum -y install wget
@@ -24,9 +24,9 @@ RUN yum -y update && yum -y install wget
 # To use a specific version instead, modify the wget and rpm commands to reference the full path to the 
 # dotnet agent version rpm file you want to use instead of the wildcard specification
 # 
-# For example, to use v10.17.0 of the .NET agent, you would run the following command:
-# RUN wget https://download.newrelic.com/dot_net_agent/previous_releases/10.17.0/newrelic-dotnet-agent-10.17.0-1.x86_64.rpm \
-#     && rpm -i download.newrelic.com/dot_net_agent/previous_releases/10.17.0/newrelic-dotnet-agent-10.17.0-1.x86_64.rpm \
+# For example, to use v10.21.1 of the .NET agent, you would run the following command:
+# RUN wget https://download.newrelic.com/dot_net_agent/previous_releases/10.21.1/newrelic-dotnet-agent-10.21.1-1.x86_64.rpm \
+#     && rpm -i download.newrelic.com/dot_net_agent/previous_releases/10.21.1/newrelic-dotnet-agent-10.21.1-1.x86_64.rpm \
 #     && rm -rf download.newrelic.com
 # 
 # the agent is installed at /usr/local/new-relic-dotnet-agent

--- a/docker-agent-installed/centos/WeatherForecast.csproj
+++ b/docker-agent-installed/centos/WeatherForecast.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docker-agent-installed/ubuntu/Dockerfile
+++ b/docker-agent-installed/ubuntu/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-jammy AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy AS base
 WORKDIR /app
 EXPOSE 80
 ENV ASPNETCORE_URLS=http://+:80
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS build 
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
 
 WORKDIR /src
 COPY . ./
@@ -16,8 +16,8 @@ FROM base AS final
 #
 # To use a specific version instead, modify the apt-get install command to reference a specific version
 #
-# For example, to use v10.17.0 of the .NET agent, you would use the following apt-get install command:
-#  apt-get install -y newrelic-dotnet-agent=10.17.0
+# For example, to use v10.21.1 of the .NET agent, you would use the following apt-get install command:
+#  apt-get install -y newrelic-dotnet-agent=10.21.1
 #
 # the agent is installed at /usr/local/new-relic-dotnet-agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \

--- a/docker-agent-installed/ubuntu/WeatherForecast.csproj
+++ b/docker-agent-installed/ubuntu/WeatherForecast.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docker-agent-nuget/alpine/Dockerfile
+++ b/docker-agent-nuget/alpine/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
 WORKDIR /app
 EXPOSE 80
 ENV ASPNETCORE_URLS=http://+:80
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build 
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 
 WORKDIR /src
 COPY . ./

--- a/docker-agent-nuget/alpine/WeatherForecast.csproj
+++ b/docker-agent-nuget/alpine/WeatherForecast.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docker-agent-nuget/centos/Dockerfile
+++ b/docker-agent-nuget/centos/Dockerfile
@@ -4,7 +4,7 @@ EXPOSE 80
 ENV ASPNETCORE_URLS=http://+:80
 
 # build using the Debian-based .NET SDK image
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build 
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /src
 COPY . ./
@@ -14,7 +14,7 @@ RUN dotnet publish -c Release -o /app/publish
 FROM base AS final
 
 # install asp.netcore
-RUN dnf install aspnetcore-runtime-7.0 -y
+RUN dnf install aspnetcore-runtime-8.0 -y
 
 # Enable the agent - note that the NuGet package installs to /app/newrelic
 ENV CORECLR_ENABLE_PROFILING=1 \

--- a/docker-agent-nuget/centos/WeatherForecast.csproj
+++ b/docker-agent-nuget/centos/WeatherForecast.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docker-agent-nuget/ubuntu/Dockerfile
+++ b/docker-agent-nuget/ubuntu/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-jammy AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy AS base
 WORKDIR /app
 EXPOSE 80
 ENV ASPNETCORE_URLS=http://+:80
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS build 
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
 
 WORKDIR /src
 COPY . ./

--- a/docker-agent-nuget/ubuntu/WeatherForecast.csproj
+++ b/docker-agent-nuget/ubuntu/WeatherForecast.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Update the test projects and docker .NET SDK/runtime images to .NET 8.

I verified that:
* The solution file builds
* All of the dockerfiles build
* I tested running one of the resulting docker images and verified that agent logs were created when the weatherforecast API was exercised

