### PR TITLE
chore: Add a k8s agent operator example

### DIFF
--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy AS base
+WORKDIR /app
+EXPOSE 80
+ENV ASPNETCORE_URLS=http://+:80
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
+WORKDIR /src
+RUN dotnet new webapi --name WeatherForecast --output ./
+RUN dotnet publish -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+
+# test by browsing to http://<hostname>:<port>/WeatherForecast
+ENTRYPOINT ["dotnet", "WeatherForecast.dll"]

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,75 @@
+# Deploy the .NET agent with the New Relic Kubernetes Agent Operator
+
+This example demonstrates building and deploying a .NET application in Kubernetes, using the [New Relic Kubernetes Agent Operator](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/) to automatically install the New Relic .NET agent. Note that there is no need to add commands to `Dockerfile` or use the `NewRelic.Agent` Nuget package to install the .NET agent as shown in other examples in this repo -- the agent operator takes care of that for you automatically.
+
+## Custom Instrumentation Resource Definition
+The Kubernetes Agent Operator is added to each namespace that you want to monitor by way of a custom resource definition. You can either add the following `Instrumentation.yml` file to your Helm chart (as shown in this example under `chart/templates`), or you can apply the custom resource definition to each namespace with the following command (after following steps 1 through 3 below): 
+```
+kubectl apply -f Instrumentation.yml -n <your namespace>
+```
+
+##### Instrumentation.yml:
+```
+apiVersion: newrelic.com/v1alpha1
+kind: Instrumentation
+metadata:
+    labels:
+        app.kubernetes.io/name: instrumentation
+        app.kubernetes.io/created-by: k8s-agents-operator
+    name: newrelic-instrumentation
+spec:
+    dotnet:
+        image: newrelic/newrelic-dotnet-init:latest
+```
+This example uses the latest .NET init container (containing the latest .NET agent release) - for an actual production app, you should use a specific version tag. See the [.NET Init Container Docker Hub Repo](https://hub.docker.com/repository/docker/newrelic/newrelic-dotnet-init/general) for the full list of available versions.
+
+## Installation
+This example uses MiniKube, but the same process can be used for other Kubernetes environments. 
+
+1. Add the `jetstack` and `k8s-agents-operator` Helm chart repositories:
+```
+helm repo add jetstack https://charts.jetstack.io
+helm repo add k8s-agents-operator https://newrelic.github.io/k8s-agents-operator
+```
+
+2. Install the `cert-manager` Helm chart:
+```
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true
+```
+
+3. Install the `k8s-agents-operator` Helm chart in its own namespace and specify your New Relic license key:
+```
+helm upgrade --install k8s-agents-operator k8s-agents-operator/k8s-agents-operator \
+  --namespace k8s-agents-operator \
+  --create-namespace \
+  --set=licenseKey=<NEW RELIC INGEST LICENSE KEY>
+```
+
+Note that this example creates a standalone installation of the Kubernetes agent operator. For a production deployment, we recommend installing the agent operator in addition to the `nri-bundle` - refer to [these instructions](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/#bundle-installation) for more details.
+
+4. Create a secret in each namespace where you want the agent to be installed, containing a New Relic ingest license key (we use the `default` namespace in this exmple):
+```
+kubectl create secret generic newrelic-key-secret \
+  --namespace default \
+  -- create-namespace \
+  --from-literal=new_relic_license_key=<NEW RELIC INGEST LICENSE KEY>
+```  
+
+5. Build the .NET test app container:
+```
+minikube image build -t weatherforecast:latest .
+```
+
+6. Deploy the .NET test app Helm chart:
+```
+helm install test-app-dotnet ./chart/ -n default
+```
+
+7. Start the .NET test app service:
+```
+minikube service test-app-dotnet-service
+```
+This will show the URL where the service is listening. From a browser, navigate to `<url>/WeatherForecast` and within a few minutes, you should see a `k8s-test-app-dotnet` APM entity in the New Relic UI.

--- a/kubernetes/chart/.helmignore
+++ b/kubernetes/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/chart/Chart.yaml
+++ b/kubernetes/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test-app-dotnet
+description: .NET Test Application with New Relic agents operator
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/kubernetes/chart/templates/deployment.yaml
+++ b/kubernetes/chart/templates/deployment.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-dotnet
+spec:
+  selector:
+    matchLabels:
+      app: test-app-dotnet
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-app-dotnet
+      annotations:
+        instrumentation.newrelic.com/inject-dotnet: "true"
+    spec:
+      containers:
+        - name: test-app-dotnet
+          image: weatherforecast:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 80
+          env:
+          # required for the New Relic agent to start
+          - name: NEW_RELIC_APP_NAME
+            value: k8s-test-app-dotnet
+          # Other environment variables can be added here. See https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration for more information.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-dotnet-service
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: test-app-dotnet

--- a/kubernetes/chart/templates/instrumentation.yaml
+++ b/kubernetes/chart/templates/instrumentation.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: newrelic.com/v1alpha1
+kind: Instrumentation
+metadata:
+  labels:
+    app.kubernetes.io/name: instrumentation
+    app.kubernetes.io/created-by: k8s-agents-operator
+  name: newrelic-instrumentation
+spec:
+  dotnet:
+    # this sample uses the latest version of the .NET init container, but for a production app, you should use a specific version tag. 
+    # See https://hub.docker.com/repository/docker/newrelic/newrelic-dotnet-init/general for a list of available tags.
+    image: newrelic/newrelic-dotnet-init:latest 
+


### PR DESCRIPTION
Adds an example showing how to use the Kubernetes Agent Operator to automatically install the .NET agent.