### PR TITLE
feat: Add example for ignoring status code errors

### DIFF
--- a/ignore-errors/Dockerfile
+++ b/ignore-errors/Dockerfile
@@ -1,0 +1,35 @@
+# Learn about building .NET container images:
+# https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY webapi/*.csproj .
+RUN dotnet restore
+
+# copy and publish app and libraries
+COPY webapi/* .
+RUN dotnet publish --no-restore -o /app
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy
+
+# install New Relic .NET agent
+RUN apt update && apt install -y wget
+RUN wget https://download.newrelic.com/dot_net_agent/previous_releases/10.27.0/newrelic-dotnet-agent_10.27.0_amd64.deb -O agent.deb
+RUN dpkg -i agent.deb
+
+# configure agent env vars
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
+ENV CORECLR_PROFILER_PATH="/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so"
+ENV CORECLR_NEWRELIC_HOME="/usr/local/newrelic-dotnet-agent"
+ENV NEW_RELIC_APP_NAME="YourAppName"
+ENV NEW_RELIC_LICENSE_KEY="YourLicenseKey"
+ENV NEWRELIC_LOG_LEVEL="debug"
+
+# run app
+EXPOSE 8080
+WORKDIR /app
+COPY --from=build /app .
+ENTRYPOINT ["./webapi"]

--- a/ignore-errors/README.md
+++ b/ignore-errors/README.md
@@ -5,10 +5,10 @@ This folder contains a Dockerfile and a simple ASP.NET Core web api application 
 Steps for testing:
 
 1. Edit the Dockerfile to set your New Relic license key and application name. 
-1. `docker build . -t errortest`
-1. `docker run -p 8080:8080 errortest`
-1. In a browser or with curl, make several requests to http://localhost:8080/weatherforecast and then one or two requests to http://localhost:8080/throwerror
-1. Observe in New Relic APM that there should be some 422 errors in your errors inbox for the test app
-1. Now run the container again with the ignore error codes env var set: `docker run -p 8080:8080 -e 'NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES=422' errortest`
-1. Repeat step 4
-1. There should be no additional 422 errors in your errors inbox
+2. `docker build . -t errortest`
+3. `docker run -p 8080:8080 errortest`
+4. In a browser or with curl, make several requests to http://localhost:8080/weatherforecast and then one or two requests to http://localhost:8080/throwerror
+5. Observe in New Relic APM that there should be some 422 errors in your errors inbox for the test app
+6. Now run the container again with the ignore error codes env var set: `docker run -p 8080:8080 -e 'NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES=422' errortest`
+7. Repeat step 4
+8. There should be no additional 422 errors in your errors inbox

--- a/ignore-errors/README.md
+++ b/ignore-errors/README.md
@@ -1,0 +1,14 @@
+# New Relic .NET Agent Samples - Ignore Errors
+
+This folder contains a Dockerfile and a simple ASP.NET Core web api application that can be used to test the agent's ability to ignore error codes by status.
+
+Steps for testing:
+
+1. Edit the Dockerfile to set your New Relic license key and application name. 
+1. `docker build . -t errortest`
+1. `docker run -p 8080:8080 errortest`
+1. In a browser or with curl, make several requests to http://localhost:8080/weatherforecast and then one or two requests to http://localhost:8080/throwerror
+1. Observe in New Relic APM that there should be some 422 errors in your errors inbox for the test app
+1. Now run the container again with the ignore error codes env var set: `docker run -p 8080:8080 -e 'NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES=422' errortest`
+1. Repeat step 4
+1. There should be no additional 422 errors in your errors inbox

--- a/ignore-errors/webapi/Program.cs
+++ b/ignore-errors/webapi/Program.cs
@@ -1,0 +1,56 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+})
+.WithName("GetWeatherForecast")
+.WithOpenApi();
+
+// An endpoint to return an error status code for the purposes of testing the agent's ignored and expected errors features
+app.MapGet("/throwerror", () =>
+{
+    return Results.StatusCode(422);
+    
+})
+.WithName("ThrowError")
+.WithOpenApi();
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/ignore-errors/webapi/appsettings.Development.json
+++ b/ignore-errors/webapi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/ignore-errors/webapi/appsettings.json
+++ b/ignore-errors/webapi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/ignore-errors/webapi/webapi.csproj
+++ b/ignore-errors/webapi/webapi.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Add a containerized example of how to configure the agent to ignore status code errors with the `NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES` environment variable.