### PR TITLE
Update dotnet agent Dockerfile

### DIFF
--- a/docker-agent-installed/alpine/Dockerfile
+++ b/docker-agent-installed/alpine/Dockerfile
@@ -26,7 +26,7 @@ FROM base AS final
 # the agent is installed at /usr/local/new-relic-dotnet-agent
 RUN apk update && apk add --no-cache wget tar \
     && wget https://download.newrelic.com/dot_net_agent/latest_release -A '*.*amd64.tar.gz' -r \
-    && tar -xzf download.newrelic.com/dot_net_agent/latest_release/*.*amd64.tar.gz -C /usr/local \ 
+    && tar -xzf download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_arm64.tar.gz -C /usr/local \ 
     && rm -rf download.newrelic.com
 
 # Enable the agent

--- a/docker-agent-installed/alpine/Dockerfile
+++ b/docker-agent-installed/alpine/Dockerfile
@@ -26,7 +26,7 @@ FROM base AS final
 # the agent is installed at /usr/local/new-relic-dotnet-agent
 RUN apk update && apk add --no-cache wget tar \
     && wget https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_amd64.tar.gz -r \
-    && tar -xzf download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_arm64.tar.gz -C /usr/local \ 
+    && tar -xzf download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_amd64.tar.gz -C /usr/local \ 
     && rm -rf download.newrelic.com
 
 # Enable the agent

--- a/docker-agent-installed/alpine/Dockerfile
+++ b/docker-agent-installed/alpine/Dockerfile
@@ -25,7 +25,7 @@ FROM base AS final
 # 
 # the agent is installed at /usr/local/new-relic-dotnet-agent
 RUN apk update && apk add --no-cache wget tar \
-    && wget https://download.newrelic.com/dot_net_agent/latest_release -A '*.*amd64.tar.gz' -r \
+    && wget https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_amd64.tar.gz -r \
     && tar -xzf download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_arm64.tar.gz -C /usr/local \ 
     && rm -rf download.newrelic.com
 

--- a/docker-agent-installed/alpine/Dockerfile
+++ b/docker-agent-installed/alpine/Dockerfile
@@ -25,8 +25,8 @@ FROM base AS final
 # 
 # the agent is installed at /usr/local/new-relic-dotnet-agent
 RUN apk update && apk add --no-cache wget tar \
-    && wget https://download.newrelic.com/dot_net_agent/latest_release -A '*amd64.tar.gz' -r \
-    && tar -xzf download.newrelic.com/dot_net_agent/latest_release/*.tar.gz -C /usr/local \ 
+    && wget https://download.newrelic.com/dot_net_agent/latest_release -A '*.*amd64.tar.gz' -r \
+    && tar -xzf download.newrelic.com/dot_net_agent/latest_release/*.*amd64.tar.gz -C /usr/local \ 
     && rm -rf download.newrelic.com
 
 # Enable the agent


### PR DESCRIPTION
Recent change to file contents of https://download.newrelic.com/dot_net_agent/latest_release/ broke the Dockerfile because the wget would download more than one file.  The `tar` command is extracting based on a wildcard, and since more than one file matches (is expanded by the shell) it's trying to extract specific files from the first file given which don't exist in it:

https://stackoverflow.com/a/16933431

![image](https://github.com/user-attachments/assets/92ff89ef-a06a-4337-b6ba-51d3b2ae2efe)
