### PR TITLE
chore: Update Kubernetes example to reflect current usage

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -10,65 +10,49 @@ kubectl apply -f Instrumentation.yml -n <your namespace>
 
 ##### Instrumentation.yml:
 ```
-apiVersion: newrelic.com/v1alpha1
+apiVersion: newrelic.com/v1alpha2
 kind: Instrumentation
 metadata:
-    labels:
-        app.kubernetes.io/name: instrumentation
-        app.kubernetes.io/created-by: k8s-agents-operator
-    name: newrelic-instrumentation
+  name: newrelic-instrumentation-dotnet
 spec:
-    dotnet:
-        image: newrelic/newrelic-dotnet-init:latest
+  agent:
+    language: dotnet
+    image: newrelic/newrelic-dotnet-init:latest
 ```
 This example uses the latest .NET init container (containing the latest .NET agent release) - for an actual production app, you should use a specific version tag. See the [.NET Init Container Docker Hub Repo](https://hub.docker.com/repository/docker/newrelic/newrelic-dotnet-init/general) for the full list of available versions.
 
 ## Installation
 This example uses MiniKube, but the same process can be used for other Kubernetes environments. 
 
-1. Add the `jetstack` and `k8s-agents-operator` Helm chart repositories:
+1. Set the required environment variables:
 ```
-helm repo add jetstack https://charts.jetstack.io
+export NEW_RELIC_LICENSE_KEY=***
+```
+
+2. Add the `k8s-agents-operator Helm chart repository:
+```
 helm repo add k8s-agents-operator https://newrelic.github.io/k8s-agents-operator
 ```
 
-2. Install the `cert-manager` Helm chart:
-```
-helm install cert-manager jetstack/cert-manager \
-  --namespace cert-manager \
-  --create-namespace \
-  --set crds.enabled=true
-```
-
-3. Install the `k8s-agents-operator` Helm chart in its own namespace and specify your New Relic license key:
+3. Install the `k8s-agents-operator` Helm chart:
 ```
 helm upgrade --install k8s-agents-operator k8s-agents-operator/k8s-agents-operator \
-  --namespace k8s-agents-operator \
-  --create-namespace \
-  --set=licenseKey=<NEW RELIC INGEST LICENSE KEY>
+    --set=licenseKey=${NEW_RELIC_LICENSE_KEY}
 ```
 
 Note that this example creates a standalone installation of the Kubernetes agent operator. For a production deployment, we recommend installing the agent operator in addition to the `nri-bundle` - refer to [these instructions](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/#bundle-installation) for more details.
 
-4. Create a secret in each namespace where you want the agent to be installed, containing a New Relic ingest license key (we use the `default` namespace in this exmple):
-```
-kubectl create secret generic newrelic-key-secret \
-  --namespace default \
-  -- create-namespace \
-  --from-literal=new_relic_license_key=<NEW RELIC INGEST LICENSE KEY>
-```  
-
-5. Build the .NET test app container:
+4. Build the .NET test app container:
 ```
 minikube image build -t weatherforecast:latest .
 ```
 
-6. Deploy the .NET test app Helm chart:
+5. Deploy the .NET test app Helm chart:
 ```
 helm install test-app-dotnet ./chart/ -n default
 ```
 
-7. Start the .NET test app service:
+6. Start the .NET test app service:
 ```
 minikube service test-app-dotnet-service
 ```

--- a/kubernetes/chart/templates/deployment.yaml
+++ b/kubernetes/chart/templates/deployment.yaml
@@ -25,12 +25,10 @@ spec:
           - name: NEW_RELIC_APP_NAME
             value: k8s-test-app-dotnet
           # Other environment variables can be added here. See https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration for more information.
-          - name: NEWRELIC_LOG_LEVEL
-            value: finest
-          - name: NEW_RELIC_LOG_CONSOLE
-            value: "1"
-          - name: NEW_RELIC_HOST
-            value: "staging-collector.newrelic.com"         
+          #- name: NEWRELIC_LOG_LEVEL
+          #  value: finest
+          #- name: NEW_RELIC_LOG_CONSOLE
+          #  value: "1"
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/chart/templates/deployment.yaml
+++ b/kubernetes/chart/templates/deployment.yaml
@@ -12,8 +12,7 @@ spec:
     metadata:
       labels:
         app: test-app-dotnet
-      annotations:
-        instrumentation.newrelic.com/inject-dotnet: "true"
+        app.newrelic.instrumentation: newrelic-dotnet-agent
     spec:
       containers:
         - name: test-app-dotnet
@@ -26,14 +25,21 @@ spec:
           - name: NEW_RELIC_APP_NAME
             value: k8s-test-app-dotnet
           # Other environment variables can be added here. See https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration for more information.
+          - name: NEWRELIC_LOG_LEVEL
+            value: finest
+          - name: NEW_RELIC_LOG_CONSOLE
+            value: "1"
+          - name: NEW_RELIC_HOST
+            value: "staging-collector.newrelic.com"         
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: test-app-dotnet-service
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
   - port: 80
+    targetPort: 80
   selector:
     app: test-app-dotnet

--- a/kubernetes/chart/templates/instrumentation.yaml
+++ b/kubernetes/chart/templates/instrumentation.yaml
@@ -1,14 +1,9 @@
 ---
-apiVersion: newrelic.com/v1alpha1
+apiVersion: newrelic.com/v1alpha2
 kind: Instrumentation
 metadata:
-  labels:
-    app.kubernetes.io/name: instrumentation
-    app.kubernetes.io/created-by: k8s-agents-operator
-  name: newrelic-instrumentation
+  name: newrelic-instrumentation-dotnet
 spec:
-  dotnet:
-    # this sample uses the latest version of the .NET init container, but for a production app, you should use a specific version tag. 
-    # See https://hub.docker.com/repository/docker/newrelic/newrelic-dotnet-init/general for a list of available tags.
-    image: newrelic/newrelic-dotnet-init:latest 
-
+  agent:
+    language: dotnet
+    image: newrelic/newrelic-dotnet-init:latest # Please ensure you're using a trusted New Relic image

--- a/kubernetes/chart/templates/instrumentation.yaml
+++ b/kubernetes/chart/templates/instrumentation.yaml
@@ -6,4 +6,6 @@ metadata:
 spec:
   agent:
     language: dotnet
-    image: newrelic/newrelic-dotnet-init:latest # Please ensure you're using a trusted New Relic image
+    # this sample uses the latest version of the .NET init container, but for a production app, you should use a specific version tag. 
+    # See https://hub.docker.com/repository/docker/newrelic/newrelic-dotnet-init/general for a list of available tags.
+    image: newrelic/newrelic-dotnet-init:latest


### PR DESCRIPTION
Updates our Kubernetes example app to use the newest version of the k8s agent operator. Also updates the README to reflect slightly different steps for install and run.