### PR TITLE
Add api-custom-attributes example app

### DIFF
--- a/NewRelicDotNetExamples.sln
+++ b/NewRelicDotNetExamples.sln
@@ -98,6 +98,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "api-error-handling", "api-e
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api-error-handling", "api-error-handling\api-error-handling.csproj", "{1C903EA8-BC15-470A-AEDA-ED7CC7474BE9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "api-custom-attributes", "api-custom-attributes", "{B2C3D4E5-F6A7-4B8C-9D0E-1F2A3B4C5D6E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api-custom-attributes", "api-custom-attributes\api-custom-attributes.csproj", "{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -276,6 +280,18 @@ Global
 		{1C903EA8-BC15-470A-AEDA-ED7CC7474BE9}.Release|x64.Build.0 = Release|Any CPU
 		{1C903EA8-BC15-470A-AEDA-ED7CC7474BE9}.Release|x86.ActiveCfg = Release|Any CPU
 		{1C903EA8-BC15-470A-AEDA-ED7CC7474BE9}.Release|x86.Build.0 = Release|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Debug|x64.Build.0 = Debug|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Debug|x86.Build.0 = Debug|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Release|x64.ActiveCfg = Release|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Release|x64.Build.0 = Release|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Release|x86.ActiveCfg = Release|Any CPU
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -304,6 +320,7 @@ Global
 		{6537B169-CB6E-48A1-9815-16C0E6B96058} = {1EA88E38-60C2-401F-BAC3-498D391B4166}
 		{4B6D963D-D7D3-49E0-A89A-9583C947C80E} = {6537B169-CB6E-48A1-9815-16C0E6B96058}
 		{1C903EA8-BC15-470A-AEDA-ED7CC7474BE9} = {A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D}
+		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0} = {B2C3D4E5-F6A7-4B8C-9D0E-1F2A3B4C5D6E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {974824D6-453F-4962-AF8A-31949A0F847E}

--- a/api-custom-attributes/Program.cs
+++ b/api-custom-attributes/Program.cs
@@ -1,0 +1,25 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using ApiCustomAttributes.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<PricingService>();
+builder.Services.AddSingleton<OrderPipeline>();
+
+var app = builder.Build();
+
+app.Urls.Add("http://localhost:5001");
+
+// POST /orders/{customerId}
+// Processes an order through multiple traced stages, demonstrating:
+//   - SetTransactionName to override the auto-generated transaction name
+//   - ITransaction.SetUserId to associate a user with the transaction
+//   - ITransaction.AddCustomAttribute for transaction-level attributes (builder pattern)
+//   - [Trace] to create child spans for each processing stage
+//   - ISpan.SetName and ISpan.AddCustomAttribute for span-level attributes (builder pattern)
+app.MapPost("/orders/{customerId}", (string customerId, OrderRequest request, OrderPipeline pipeline) =>
+    pipeline.ProcessOrder(customerId, request));
+
+app.Run();

--- a/api-custom-attributes/README.md
+++ b/api-custom-attributes/README.md
@@ -1,0 +1,176 @@
+# New Relic .NET Agent API — Custom Attributes Example
+
+This example demonstrates how to add custom attributes to transactions and spans, set transaction names, associate a user ID with a transaction, and use the `[Trace]` attribute to create child spans within a transaction.
+
+## API Methods Covered
+
+| Method | Documentation |
+|--------|---------------|
+| `ITransaction.AddCustomAttribute(string, object)` | [AddCustomAttribute](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction.AddCustomAttribute) |
+| `ISpan.AddCustomAttribute(string, object)` | [AddCustomAttribute](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ISpan.AddCustomAttribute) |
+| `ISpan.SetName(string)` | [SetName](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetName) |
+| `ITransaction.SetUserId(string)` | [SetUserId](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetUserId) |
+| `NewRelic.SetTransactionName(string, string)` | [SetTransactionName](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetTransactionName) |
+| `[Trace]` attribute | [Custom instrumentation via attributes](https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) |
+
+## Key Concepts Demonstrated
+
+### Transaction vs. Span Attributes
+
+Custom attributes can be added at two levels:
+
+- **Transaction attributes** (`ITransaction.AddCustomAttribute`): Attached to the entire transaction. Reported in errors and transaction traces.
+- **Span attributes** (`ISpan.AddCustomAttribute`): Attached to the currently executing span. Useful for adding context to specific operations within a transaction.
+
+Both methods return their respective interface (`ITransaction` / `ISpan`) to support method chaining (builder pattern). Keys are limited to 255-bytes.
+
+Supported value types ([full details](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction.AddCustomAttribute)):
+
+| .NET Type | Representation |
+|-----------|---------------|
+| `byte`, `Int16`, `Int32`, `Int64`, `sbyte`, `UInt16`, `UInt32`, `UInt64` | Integral value |
+| `float`, `double`, `decimal` | Decimal-based number |
+| `string` | Truncated at 4096 characters at ingest; empty strings supported |
+| `bool` | True or false |
+| `DateTime` | ISO-8601 string with timezone (e.g., `2020-02-13T11:31:19.5767650-08:00`) |
+| `TimeSpan` | Decimal number representing seconds |
+| `arrays`, `Lists`, and other `IEnumerable` types | JSON array (null elements filtered; requires agent 10.50.0+) |
+| Everything else | `ToString()` is called |
+
+### The `[Trace]` Attribute
+
+The `[Trace]` attribute creates a child span within an existing transaction. When invoked outside a transaction, no measurements are recorded.
+
+- Apply `[Trace]` to concrete method implementations only — it cannot be applied to interfaces or base class definitions.
+- Use `[MethodImpl(MethodImplOptions.NoInlining)]` alongside `[Trace]` to prevent the JIT compiler from inlining the method, which would prevent instrumentation.
+- `[Trace]` spans nest naturally: `OrderPipeline.CalculatePrice` calls `PricingService.GetPrice`, both decorated with `[Trace]`, creating a parent-child relationship visible in the trace waterfall.
+
+### `SetTransactionName`
+
+Overrides the auto-generated transaction name. Must be called inside a transaction. Important constraints:
+
+- If called multiple times in the same transaction, the last call wins.
+- Do not use unique values (URLs, session IDs, hex values) in transaction names — use `AddCustomAttribute` instead.
+- Do not create more than 1000 unique transaction names.
+- Do not use brackets `[suffix]` at the end of the name.
+
+### `SetUserId`
+
+Associates a user ID with the current transaction. The value is stored as the agent attribute `enduser.id` and is surfaced in [Errors Inbox](https://docs.newrelic.com/docs/errors-inbox/errors-inbox/), where it powers the ["Users impacted"](https://docs.newrelic.com/docs/errors-inbox/error-impacted/#set-users) metric — showing how many unique users are affected by each error group.
+
+Requires agent version 10.9.0+. Null, empty, and whitespace values are ignored.
+
+### When `[Transaction]` Is NOT Needed
+
+The web API endpoint in this example does NOT use the `[Transaction]` attribute. The agent's built-in ASP.NET Core instrumentation automatically creates a transaction for each incoming HTTP request. The `[Transaction]` attribute is only needed when auto-instrumentation does not apply (e.g., in a `BackgroundService`).
+
+## NuGet Packages
+
+This example references two NuGet packages:
+
+- **`NewRelic.Agent`** — Bundles the agent runtime files (profiler, configuration, extensions) into the build output directory. This is one of several ways to install the agent; alternatives include OS package managers and container-based installation.
+- **`NewRelic.Agent.Api`** — Provides the `NewRelic.Api.Agent` namespace used throughout this example (`AddCustomAttribute`, `SetName`, `SetUserId`, `[Trace]`, etc.). This package is required for any application that calls the agent API directly.
+
+## How to Run
+
+### Prerequisites
+
+- .NET 10 SDK
+- A New Relic account with a license key
+
+### Run the Application
+
+This example uses the `NewRelic.Agent` NuGet package, which places the agent files under the build output directory. You must set several [environment variables](https://docs.newrelic.com/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/) to enable the .NET CLR profiler and point it to the agent.
+
+**Windows (PowerShell):**
+
+```powershell
+# Build first so the agent files are in the output directory
+dotnet build -c Release
+
+# Set the required environment variables for the .NET agent
+$env:CORECLR_ENABLE_PROFILING=1
+$env:CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+$env:CORECLR_PROFILER_PATH="$PWD\bin\Release\net10.0\newrelic\NewRelic.Profiler.dll"
+$env:CORECLR_NEWRELIC_HOME="$PWD\bin\Release\net10.0\newrelic"
+$env:NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+$env:NEW_RELIC_APP_NAME="api-custom-attributes-example"
+
+# Run the application
+dotnet run -c Release --no-build
+```
+
+**Linux / macOS (bash):**
+
+```bash
+# Build first so the agent files are in the output directory
+dotnet build -c Release
+
+# Set the required environment variables for the .NET agent
+export CORECLR_ENABLE_PROFILING=1
+export CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+export CORECLR_PROFILER_PATH="$PWD/bin/Release/net10.0/newrelic/libNewRelicProfiler.so"
+export CORECLR_NEWRELIC_HOME="$PWD/bin/Release/net10.0/newrelic"
+export NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+export NEW_RELIC_APP_NAME="api-custom-attributes-example"
+
+# Run the application
+dotnet run -c Release --no-build
+```
+
+| Variable | Purpose |
+|----------|---------|
+| `CORECLR_ENABLE_PROFILING` | Enables the .NET CLR profiler (must be `1`) |
+| `CORECLR_PROFILER` | The CLSID of the New Relic profiler |
+| `CORECLR_PROFILER_PATH` | Path to the profiler native library (`NewRelic.Profiler.dll` on Windows, `libNewRelicProfiler.so` on Linux) |
+| `CORECLR_NEWRELIC_HOME` | Path to the directory containing the agent configuration and extensions |
+| `NEW_RELIC_LICENSE_KEY` | Your New Relic license key |
+| `NEW_RELIC_APP_NAME` | The application name as it will appear in New Relic |
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/orders/{customerId}` | POST | Processes an order through Validate → CalculatePrice → PersistOrder stages, each creating a traced child span with custom attributes. |
+
+### Example Requests
+
+**Linux / macOS (bash):**
+
+```bash
+# Successful order (200 OK)
+curl -X POST http://localhost:5001/orders/CUST-100 \
+  -H "Content-Type: application/json" \
+  -d '{"orderId": "ORD-001", "region": "US", "items": [{"productId": "PROD-1", "name": "Widget", "price": 25.00, "quantity": 2}, {"productId": "PROD-2", "name": "Gadget", "price": 15.00, "quantity": 1}]}'
+
+# Order from a different region (applies discount)
+curl -X POST http://localhost:5001/orders/CUST-200 \
+  -H "Content-Type: application/json" \
+  -d '{"orderId": "ORD-002", "region": "EU", "items": [{"productId": "PROD-3", "name": "Sprocket", "price": 50.00, "quantity": 3}]}'
+
+# Trigger a validation error (empty items — returns 400)
+# Useful for observing how SetUserId and custom attributes appear on error events
+curl -X POST http://localhost:5001/orders/CUST-300 \
+  -H "Content-Type: application/json" \
+  -d '{"orderId": "ORD-003", "region": "US", "items": []}'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Successful order (200 OK)
+Invoke-RestMethod -Method POST -Uri http://localhost:5001/orders/CUST-100 `
+  -ContentType "application/json" `
+  -Body '{"orderId": "ORD-001", "region": "US", "items": [{"productId": "PROD-1", "name": "Widget", "price": 25.00, "quantity": 2}, {"productId": "PROD-2", "name": "Gadget", "price": 15.00, "quantity": 1}]}'
+
+# Order from a different region (applies discount)
+Invoke-RestMethod -Method POST -Uri http://localhost:5001/orders/CUST-200 `
+  -ContentType "application/json" `
+  -Body '{"orderId": "ORD-002", "region": "EU", "items": [{"productId": "PROD-3", "name": "Sprocket", "price": 50.00, "quantity": 3}]}'
+
+# Trigger a validation error (empty items — returns 400)
+# Useful for observing how SetUserId and custom attributes appear on error events
+Invoke-RestMethod -Method POST -Uri http://localhost:5001/orders/CUST-300 `
+  -ContentType "application/json" `
+  -Body '{"orderId": "ORD-003", "region": "US", "items": []}'
+```

--- a/api-custom-attributes/Services/OrderPipeline.cs
+++ b/api-custom-attributes/Services/OrderPipeline.cs
@@ -1,0 +1,197 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+using NewRelic.Api.Agent;
+
+namespace ApiCustomAttributes.Services;
+
+/// <summary>
+/// Demonstrates adding custom attributes to transactions and spans, setting transaction names,
+/// and associating a user ID with a transaction.
+///
+/// These methods are called from ASP.NET Core minimal API endpoints. The agent's built-in
+/// ASP.NET Core instrumentation automatically creates a transaction for each incoming HTTP
+/// request, so these methods do NOT need the [Transaction] attribute.
+///
+/// Methods decorated with [Trace] create child spans within the auto-instrumented transaction,
+/// providing detailed breakdowns of where time is spent.
+///
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction.AddCustomAttribute
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/
+/// </summary>
+public class OrderPipeline
+{
+    private readonly PricingService _pricingService;
+
+    public OrderPipeline(PricingService pricingService)
+    {
+        _pricingService = pricingService;
+    }
+
+    /// <summary>
+    /// Processes an order through multiple traced stages. Demonstrates:
+    ///   - SetTransactionName to override the auto-generated transaction name
+    ///   - ITransaction.SetUserId to associate the transaction with a customer
+    ///   - ITransaction.AddCustomAttribute for transaction-level context (builder pattern)
+    ///
+    /// SetTransactionName must be called inside a transaction. If called multiple times within
+    /// the same transaction, each call overwrites the previous one — the last call wins.
+    ///
+    /// Do not use unique values (URLs, session IDs, etc.) in transaction names. Use
+    /// AddCustomAttribute for such data instead. Do not create more than 1000 unique
+    /// transaction names.
+    ///
+    /// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetTransactionName
+    /// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetUserId
+    /// </summary>
+    public IResult ProcessOrder(string customerId, OrderRequest request)
+    {
+        // Override the auto-generated transaction name with something meaningful.
+        // The category becomes part of the metric name prefix. The name is limited to 255 characters.
+        NewRelic.Api.Agent.NewRelic.SetTransactionName("Custom", "ProcessOrder");
+
+        var transaction = NewRelic.Api.Agent.NewRelic.GetAgent().CurrentTransaction;
+
+        // Associate a user ID with this transaction. The value is stored as the agent
+        // attribute "enduser.id" and is surfaced in Errors Inbox, where it powers the
+        // "Users impacted" metric — showing how many unique users are affected by each
+        // error group.
+        // Requires agent version 10.9.0+. Null, empty, and whitespace values are ignored.
+        // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetUserId
+        // See: https://docs.newrelic.com/docs/errors-inbox/error-impacted/#set-users
+        transaction.SetUserId(customerId);
+
+        // Add custom attributes to the transaction using the builder pattern.
+        // These are reported in errors and transaction traces.
+        // Keys are limited to 255-bytes.
+        //
+        // Supported value types (see docs link below for full details):
+        //   - Integral types: byte, Int16, Int32, Int64, sbyte, UInt16, UInt32, UInt64
+        //   - Decimal types: float, double, decimal
+        //   - string (truncated at 4096 characters at ingest; empty strings supported)
+        //   - bool
+        //   - DateTime (serialized as ISO-8601 with timezone)
+        //   - TimeSpan (serialized as decimal seconds)
+        //   - arrays, Lists, and other IEnumerable types (serialized as JSON array;
+        //     null elements filtered out; requires agent version 10.50.0+)
+        //   - All other types: ToString() is called
+        //
+        // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction.AddCustomAttribute
+        // Scalar types
+        transaction
+            .AddCustomAttribute("orderId", request.OrderId)                              // string
+            .AddCustomAttribute("itemCount", request.Items.Count)                        // int
+            .AddCustomAttribute("region", request.Region)                                // string
+            .AddCustomAttribute("isExpressShipping", request.Region == "US")             // bool
+            .AddCustomAttribute("orderTimestamp", DateTime.UtcNow)                       // DateTime → ISO-8601
+            .AddCustomAttribute("processingWindow", TimeSpan.FromMinutes(30));           // TimeSpan → seconds
+
+        // Validate: reject empty orders so we can observe how SetUserId and custom
+        // attributes appear on error events in the UI.
+        if (request.Items.Count == 0)
+        {
+            NewRelic.Api.Agent.NewRelic.NoticeError(
+                "Order validation failed: order must contain at least one item",
+                new Dictionary<string, object>
+                {
+                    { "orderId", request.OrderId },
+                    { "customerId", customerId }
+                });
+
+            return Results.BadRequest(new { error = "Order must contain at least one item" });
+        }
+
+        // Array types (requires agent version 10.50.0+)
+        // All IEnumerable types are serialized as JSON arrays. Null elements are filtered out.
+        // Elements are individually converted using the same type rules as scalar values.
+        transaction
+            .AddCustomAttribute("productIds", request.Items.Select(i => i.ProductId).ToArray())      // projected string[] via LINQ
+            .AddCustomAttribute("quantities", new List<int> { 2, 1, 3 })                             // List<int>
+            .AddCustomAttribute("prices", request.Items.Select(i => i.Price));                        // IEnumerable<decimal> (lazy)
+
+        // Process the order through traced stages.
+        // Each [Trace]-decorated method creates a child span within this transaction.
+        ValidateOrder(request);
+        var total = CalculatePrice(request);
+        PersistOrder(request, total);
+
+        return Results.Ok(new { message = "Order processed", orderId = request.OrderId, total });
+    }
+
+    /// <summary>
+    /// Demonstrates [Trace] to create a child span, and ISpan.AddCustomAttribute / ISpan.SetName.
+    ///
+    /// The [Trace] attribute instructs the agent to time this method invocation within the
+    /// parent transaction. When invoked outside a transaction, no measurements are recorded.
+    ///
+    /// ISpan.AddCustomAttribute returns ISpan for method chaining (builder pattern).
+    /// ISpan.SetName changes the name of the segment/span reported to New Relic.
+    ///
+    /// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ISpan.AddCustomAttribute
+    /// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetName
+    /// </summary>
+    [Trace]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ValidateOrder(OrderRequest request)
+    {
+        var span = NewRelic.Api.Agent.NewRelic.GetAgent().CurrentSpan;
+
+        // Rename the span and add custom attributes using the builder pattern.
+        // SetName requires agent version 10.1.0+.
+        span
+            .SetName("Validate")
+            .AddCustomAttribute("validationType", "full")
+            .AddCustomAttribute("itemCount", request.Items.Count);
+
+        // Simulate validation work
+        Thread.Sleep(10);
+    }
+
+    /// <summary>
+    /// Demonstrates a [Trace] span that calls into another traced method, creating nested spans:
+    /// [Transaction] → CalculatePrice [Trace] → GetPrice [Trace]
+    ///
+    /// This nesting is visible in the distributed trace waterfall.
+    /// </summary>
+    [Trace]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private decimal CalculatePrice(OrderRequest request)
+    {
+        var span = NewRelic.Api.Agent.NewRelic.GetAgent().CurrentSpan;
+        span.SetName("CalculatePrice");
+
+        var baseTotal = _pricingService.GetPrice(request.Items);
+
+        // Apply a regional discount
+        var discount = request.Region == "US" ? 0.0m : 0.05m;
+        var total = baseTotal * (1 - discount);
+
+        span.AddCustomAttribute("baseTotal", baseTotal)
+            .AddCustomAttribute("discount", discount)
+            .AddCustomAttribute("finalTotal", total);
+
+        return total;
+    }
+
+    /// <summary>
+    /// Demonstrates a [Trace] span for a simulated persistence operation.
+    /// </summary>
+    [Trace]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void PersistOrder(OrderRequest request, decimal total)
+    {
+        var span = NewRelic.Api.Agent.NewRelic.GetAgent().CurrentSpan;
+        span
+            .SetName("PersistOrder")
+            .AddCustomAttribute("orderId", request.OrderId)
+            .AddCustomAttribute("total", total);
+
+        // Simulate database write
+        Thread.Sleep(25);
+    }
+}
+
+public record OrderRequest(string OrderId, string Region, List<OrderItem> Items);
+
+public record OrderItem(string ProductId, string Name, decimal Price, int Quantity);

--- a/api-custom-attributes/Services/PricingService.cs
+++ b/api-custom-attributes/Services/PricingService.cs
@@ -1,0 +1,52 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+using NewRelic.Api.Agent;
+
+namespace ApiCustomAttributes.Services;
+
+/// <summary>
+/// Demonstrates nested [Trace] spans. This service is called from OrderPipeline.CalculatePrice(),
+/// which is itself a [Trace] method, creating a second level of nesting:
+///
+///   auto-instrumented web transaction
+///     → CalculatePrice [Trace]
+///       → GetPrice [Trace]
+///
+/// This nesting is visible in the distributed trace waterfall as nested child spans.
+/// </summary>
+public class PricingService
+{
+    /// <summary>
+    /// Calculates the base price for a list of items. Demonstrates a nested [Trace] span
+    /// with custom attributes for the pricing calculation details.
+    ///
+    /// The [MethodImpl(MethodImplOptions.NoInlining)] attribute prevents the JIT compiler from
+    /// inlining this method, which would prevent the [Trace] attribute from working.
+    ///
+    /// See: https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/
+    /// </summary>
+    [Trace]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public decimal GetPrice(List<OrderItem> items)
+    {
+        var span = NewRelic.Api.Agent.NewRelic.GetAgent().CurrentSpan;
+        span.SetName("GetPrice");
+
+        var total = 0m;
+        foreach (var item in items)
+        {
+            total += item.Price * item.Quantity;
+        }
+
+        span
+            .AddCustomAttribute("lineItemCount", items.Count)
+            .AddCustomAttribute("calculatedTotal", total);
+
+        // Simulate pricing lookup latency
+        Thread.Sleep(15);
+
+        return total;
+    }
+}

--- a/api-custom-attributes/api-custom-attributes.csproj
+++ b/api-custom-attributes/api-custom-attributes.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>default</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Use the latest version of the NewRelic.Agent package.
+      NOTE: For a production app, you should always reference a specific package version
+    -->
+    <PackageReference Include="NewRelic.Agent" Version="*" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="*" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

New example application demonstrating the .NET agent's custom attributes API:

- `ITransaction.AddCustomAttribute` and `ISpan.AddCustomAttribute` with builder pattern chaining
- Supported value types: string, int, bool, DateTime, TimeSpan, and array/List/IEnumerable (agent 10.50.0+)
- `SetTransactionName` for overriding auto-generated transaction names
- `SetUserId` for powering the "Users impacted" metric in Errors Inbox
- `ISpan.SetName` for renaming spans
- `[Trace]` attribute for creating child spans, including nested spans across service boundaries
- Correct `[Transaction]` absence on web endpoints (auto-instrumented by ASP.NET Core)

All behavioral claims in code comments and the README are verified against the API source code or official docs at docs.newrelic.com.