### PR TITLE
Add api-custom-events-and-metrics example

### DIFF
--- a/NewRelicDotNetExamples.sln
+++ b/NewRelicDotNetExamples.sln
@@ -102,6 +102,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "api-custom-attributes", "ap
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api-custom-attributes", "api-custom-attributes\api-custom-attributes.csproj", "{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "api-custom-events-and-metrics", "api-custom-events-and-metrics", "{E889351A-92EC-B9D4-C4E3-CC67B911FB4D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api-custom-events-and-metrics", "api-custom-events-and-metrics\api-custom-events-and-metrics.csproj", "{E8A888FF-B716-49D9-8CEB-284F11170B09}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -292,6 +296,18 @@ Global
 		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Release|x64.Build.0 = Release|Any CPU
 		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Release|x86.ActiveCfg = Release|Any CPU
 		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0}.Release|x86.Build.0 = Release|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Debug|x64.Build.0 = Debug|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Debug|x86.Build.0 = Debug|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Release|x64.ActiveCfg = Release|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Release|x64.Build.0 = Release|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Release|x86.ActiveCfg = Release|Any CPU
+		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -321,6 +337,7 @@ Global
 		{4B6D963D-D7D3-49E0-A89A-9583C947C80E} = {6537B169-CB6E-48A1-9815-16C0E6B96058}
 		{1C903EA8-BC15-470A-AEDA-ED7CC7474BE9} = {A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D}
 		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0} = {B2C3D4E5-F6A7-4B8C-9D0E-1F2A3B4C5D6E}
+		{E8A888FF-B716-49D9-8CEB-284F11170B09} = {E889351A-92EC-B9D4-C4E3-CC67B911FB4D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {974824D6-453F-4962-AF8A-31949A0F847E}

--- a/api-custom-events-and-metrics/Program.cs
+++ b/api-custom-events-and-metrics/Program.cs
@@ -1,0 +1,104 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using ApiCustomEventsAndMetrics.Services;
+using NewRelic.Api.Agent;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<CheckoutService>();
+builder.Services.AddSingleton<CacheService>();
+
+// Register the background service. Unlike web request handlers (which are
+// auto-instrumented), BackgroundService methods need the [Transaction] attribute
+// for the agent to create a transaction.
+builder.Services.AddHostedService<PeriodicMaintenanceService>();
+
+var app = builder.Build();
+
+app.Urls.Add("http://localhost:5003");
+
+// POST /checkout
+// Processes a checkout request. Demonstrates RecordCustomEvent and
+// RecordResponseTimeMetric within an auto-instrumented web transaction.
+app.MapPost("/checkout", (CheckoutRequest request, CheckoutService checkoutService) =>
+    checkoutService.ProcessCheckout(request));
+
+// GET /products/{id}
+// Retrieves a product with cache hit/miss tracking via IncrementCounter.
+app.MapGet("/products/{id}", (string id, CacheService cache) =>
+{
+    var cached = cache.Get(id);
+    if (cached is not null)
+    {
+        return Results.Ok(cached);
+    }
+
+    // Simulate a slow database lookup on cache miss
+    Thread.Sleep(Random.Shared.Next(20, 100));
+    var product = new { id, name = $"Product {id}", price = Random.Shared.Next(10, 500) };
+    cache.Set(id, product);
+    return Results.Ok(product);
+});
+
+app.Run();
+
+/// <summary>
+/// A BackgroundService that periodically runs a simulated maintenance task and records
+/// its duration using RecordMetric.
+///
+/// RecordMetric records a duration in seconds. Use it when you have a timing already
+/// expressed in seconds (e.g., from Stopwatch.Elapsed.TotalSeconds). Use
+/// RecordResponseTimeMetric when your timing is in milliseconds.
+///
+/// BackgroundService methods are not auto-instrumented by the .NET agent. The
+/// [Transaction] attribute is required on the method that does the work so the
+/// agent creates a transaction for metric correlation.
+///
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#RecordMetric
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/
+/// </summary>
+public class PeriodicMaintenanceService : BackgroundService
+{
+    private static readonly Random Random = new();
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+            RunMaintenanceTask();
+        }
+    }
+
+    /// <summary>
+    /// Runs a simulated maintenance task and records its duration in seconds. This
+    /// method has [Transaction] because BackgroundService is not auto-instrumented —
+    /// without it, the agent would not create a transaction and the metric would not
+    /// be correlated with APM data.
+    ///
+    /// [MethodImpl(MethodImplOptions.NoInlining)] prevents the JIT compiler from
+    /// inlining this method, which would make the [Transaction] attribute ineffective.
+    /// </summary>
+    [Transaction]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void RunMaintenanceTask()
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        // Simulate a maintenance operation (e.g., cache expiry sweep, index rebuild)
+        Thread.Sleep(Random.Next(100, 500));
+
+        stopwatch.Stop();
+
+        // RecordMetric records a duration in seconds. The metric name must start with
+        // "Custom/". Use this when your timing is naturally expressed in seconds; use
+        // RecordResponseTimeMetric when your timing is in milliseconds.
+        // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#RecordMetric
+        NewRelic.Api.Agent.NewRelic.RecordMetric(
+            "Custom/Maintenance/TaskDuration",
+            (float)stopwatch.Elapsed.TotalSeconds);
+    }
+}

--- a/api-custom-events-and-metrics/README.md
+++ b/api-custom-events-and-metrics/README.md
@@ -19,7 +19,7 @@ The agent API provides two fundamentally different ways to record custom data:
 
 - **Custom events** (`RecordCustomEvent`) create individual, queryable event rows with arbitrary key-value attributes. Use them for business analytics where you need to filter, facet, and alert on specific attribute values — for example, "show me all checkouts over $100 in the US region."
 
-- **Custom metrics** (`RecordMetric`, `IncrementCounter`) create pre-aggregated metric timeslices. Use them for numeric measurements where you care about averages, percentiles, and trends — not individual occurrences.
+- **Custom metrics** (`RecordMetric`, `IncrementCounter`) create pre-aggregated metric timeslices. `RecordMetric` records a duration value; `IncrementCounter` records an  integer counter. Use them when you care about averages, min, max, and counts over time — not individual occurrences.
 
 ### RecordMetric
 
@@ -75,7 +75,7 @@ $env:NEW_RELIC_APP_NAME="api-custom-events-and-metrics-example"
 dotnet run -c Release --no-build
 ```
 
-**Linux / macOS (bash):**
+**Linux (bash):**
 
 ```bash
 # Build first so the agent files are in the output directory
@@ -113,7 +113,7 @@ The `PeriodicMaintenanceService` background service runs a simulated maintenance
 
 ### Example Requests
 
-**Linux / macOS (bash):**
+**Linux (bash):**
 
 ```bash
 # Successful checkout (200 OK) — verify the app is running

--- a/api-custom-events-and-metrics/README.md
+++ b/api-custom-events-and-metrics/README.md
@@ -1,0 +1,177 @@
+# New Relic .NET Agent API — Custom Events and Metrics Example
+
+This example demonstrates how to use the New Relic .NET agent's custom event and metric APIs to record business-level data and numeric measurements.
+
+## API Methods Covered
+
+| Method | Documentation |
+|--------|---------------|
+| `RecordCustomEvent` | [RecordCustomEvent](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#RecordCustomEvent) |
+| `RecordMetric` | [RecordMetric](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#RecordMetric) |
+| `IncrementCounter` | [IncrementCounter](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#IncrementCounter) |
+| `[Transaction]` attribute | [Custom instrumentation via attributes](https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) |
+
+## Key Concepts Demonstrated
+
+### Custom Events vs. Custom Metrics
+
+The agent API provides two fundamentally different ways to record custom data:
+
+- **Custom events** (`RecordCustomEvent`) create individual, queryable event rows with arbitrary key-value attributes. Use them for business analytics where you need to filter, facet, and alert on specific attribute values — for example, "show me all checkouts over $100 in the US region."
+
+- **Custom metrics** (`RecordMetric`, `IncrementCounter`) create pre-aggregated metric timeslices. Use them for numeric measurements where you care about averages, percentiles, and trends — not individual occurrences.
+
+### RecordMetric
+
+`RecordMetric(string name, float value)` records a duration in seconds. The metric name must start with `Custom/` ([RecordMetric docs](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#RecordMetric)). A companion method, `RecordResponseTimeMetric(string name, long millis)`, is also available and behaves identically except that its value is in milliseconds ([RecordResponseTimeMetric docs](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#RecordResponseTimeMetric)).
+
+### IncrementCounter
+
+`IncrementCounter(string name)` increments a metric counter by exactly 1 per call. There is no "increment by N" variant — use `RecordMetric` if you need to record a duration value. Counter names must start with `Custom/` ([IncrementCounter docs](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#IncrementCounter)).
+
+### Custom Event Requirements
+
+Event type names are limited to 255 characters and may contain alphanumeric characters, colons (`:`), and underscores (`_`). Certain event type name prefixes are reserved by New Relic and will be dropped — see [data requirements and limits](https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/) for the full list. When using the APM agent API, each event supports a maximum of 64 attributes ([data requirements](https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/)).
+
+### When to Use the `[Transaction]` Attribute
+
+The agent's built-in ASP.NET Core instrumentation automatically creates a transaction for each incoming HTTP request. Service methods called from these endpoints are already within a transaction and do **not** need the `[Transaction]` attribute.
+
+The `[Transaction]` attribute is needed when the agent's auto-instrumentation does not apply — for example, in a `BackgroundService`. This example includes `PeriodicMaintenanceService`, a `BackgroundService` whose periodic work method uses `[Transaction]` to ensure the agent creates a transaction.
+
+## How to Run
+
+### Prerequisites
+
+- .NET 10 SDK
+- A New Relic account with a license key
+
+### NuGet Packages
+
+This example references two NuGet packages:
+
+- **`NewRelic.Agent`** — Bundles the agent runtime files (profiler, configuration, extensions) into the build output directory. This is one of several ways to install the agent; alternatives include OS package managers and container-based installation.
+- **`NewRelic.Agent.Api`** — Provides the `NewRelic.Api.Agent` namespace used throughout this example (`RecordCustomEvent`, `RecordMetric`, `IncrementCounter`, `[Transaction]`). This package is required for any application that calls the agent API directly.
+
+### Run the Application
+
+This example uses the `NewRelic.Agent` NuGet package, which places the agent files under the build output directory. You must set several [environment variables](https://docs.newrelic.com/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/) to enable the .NET CLR profiler and point it to the agent.
+
+**Windows (PowerShell):**
+
+```powershell
+# Build first so the agent files are in the output directory
+dotnet build -c Release
+
+# Set the required environment variables for the .NET agent
+$env:CORECLR_ENABLE_PROFILING=1
+$env:CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+$env:CORECLR_PROFILER_PATH="$PWD\bin\Release\net10.0\newrelic\NewRelic.Profiler.dll"
+$env:CORECLR_NEWRELIC_HOME="$PWD\bin\Release\net10.0\newrelic"
+$env:NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+$env:NEW_RELIC_APP_NAME="api-custom-events-and-metrics-example"
+
+# Run the application
+dotnet run -c Release --no-build
+```
+
+**Linux / macOS (bash):**
+
+```bash
+# Build first so the agent files are in the output directory
+dotnet build -c Release
+
+# Set the required environment variables for the .NET agent
+export CORECLR_ENABLE_PROFILING=1
+export CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+export CORECLR_PROFILER_PATH="$PWD/bin/Release/net10.0/newrelic/libNewRelicProfiler.so"
+export CORECLR_NEWRELIC_HOME="$PWD/bin/Release/net10.0/newrelic"
+export NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+export NEW_RELIC_APP_NAME="api-custom-events-and-metrics-example"
+
+# Run the application
+dotnet run -c Release --no-build
+```
+
+| Variable | Purpose |
+|----------|---------|
+| `CORECLR_ENABLE_PROFILING` | Enables the .NET CLR profiler (must be `1`) |
+| `CORECLR_PROFILER` | The CLSID of the New Relic profiler |
+| `CORECLR_PROFILER_PATH` | Path to the profiler native library (`NewRelic.Profiler.dll` on Windows, `libNewRelicProfiler.so` on Linux) |
+| `CORECLR_NEWRELIC_HOME` | Path to the directory containing the agent configuration and extensions |
+| `NEW_RELIC_LICENSE_KEY` | Your New Relic license key |
+| `NEW_RELIC_APP_NAME` | The application name as it will appear in New Relic |
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/checkout` | POST | Processes a checkout. Records `CheckoutCompleted` or `CheckoutFailed` custom events and increments a failure counter on validation errors. |
+| `/products/{id}` | GET | Retrieves a product with cache hit/miss tracking via `IncrementCounter`. |
+
+The `PeriodicMaintenanceService` background service runs a simulated maintenance task every 30 seconds and records its duration (`Custom/Maintenance/TaskDuration`) in seconds using `RecordMetric`.
+
+### Example Requests
+
+**Linux / macOS (bash):**
+
+```bash
+# Successful checkout (200 OK) — verify the app is running
+curl -X POST http://localhost:5003/checkout \
+  -H "Content-Type: application/json" \
+  -d '{"customerId": "CUST-100", "totalAmount": 79.99, "items": [{"productId": "PROD-1", "name": "Widget", "price": 49.99, "quantity": 1}, {"productId": "PROD-2", "name": "Gadget", "price": 30.00, "quantity": 1}], "paymentMethod": "credit_card", "region": "us-east"}'
+
+# Failed checkout — empty cart (400 Bad Request)
+curl -X POST http://localhost:5003/checkout \
+  -H "Content-Type: application/json" \
+  -d '{"customerId": "CUST-200", "totalAmount": 0, "items": [], "paymentMethod": "credit_card", "region": "us-west"}'
+
+# Product lookup — first request is a cache miss, second is a cache hit
+curl http://localhost:5003/products/PROD-42
+curl http://localhost:5003/products/PROD-42
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Successful checkout (200 OK) — verify the app is running
+Invoke-RestMethod -Method POST -Uri http://localhost:5003/checkout `
+  -ContentType "application/json" `
+  -Body '{"customerId": "CUST-100", "totalAmount": 79.99, "items": [{"productId": "PROD-1", "name": "Widget", "price": 49.99, "quantity": 1}, {"productId": "PROD-2", "name": "Gadget", "price": 30.00, "quantity": 1}], "paymentMethod": "credit_card", "region": "us-east"}'
+
+# Failed checkout — empty cart (400 Bad Request)
+Invoke-RestMethod -Method POST -Uri http://localhost:5003/checkout `
+  -ContentType "application/json" `
+  -Body '{"customerId": "CUST-200", "totalAmount": 0, "items": [], "paymentMethod": "credit_card", "region": "us-west"}'
+
+# Product lookup — first request is a cache miss, second is a cache hit
+Invoke-RestMethod -Uri http://localhost:5003/products/PROD-42
+Invoke-RestMethod -Uri http://localhost:5003/products/PROD-42
+```
+
+## What to Look for in New Relic
+
+- Custom events are queryable via NRQL using `FROM <EventType>` syntax
+  ([custom events docs](https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes/)):
+  ```
+  SELECT * FROM CheckoutCompleted SINCE 1 hour ago
+  SELECT average(totalAmount) FROM CheckoutCompleted FACET region SINCE 1 hour ago
+  SELECT count(*) FROM CheckoutFailed FACET reason SINCE 1 hour ago
+  ```
+
+- Custom metrics (from `RecordMetric` and `IncrementCounter`) are queryable as APM metric timeslice data via `FROM Metric` using `newrelic.timeslice.value` and `metricTimesliceName`. An `entity.guid` (or `appName`) filter is required to scope the query to your application
+  ([Query APM metric timeslice data with NRQL](https://docs.newrelic.com/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql/)):
+  ```sql
+  SELECT average(newrelic.timeslice.value) AS `Custom/Cache/Hits`
+  FROM Metric
+  WHERE metricTimesliceName = 'Custom/Cache/Hits'
+    AND entity.guid = '<your-entity-guid>'
+  SINCE 60 minutes ago
+
+  -- Discover all custom metric names recorded by your app:
+  SELECT uniques(metricTimesliceName) FROM Metric
+  WHERE appName = '<your-app-name>'
+    AND newrelic.timeslice.value IS NOT NULL
+    AND metricTimesliceName LIKE 'Custom/%'
+  SINCE 60 minutes ago
+  ```

--- a/api-custom-events-and-metrics/Services/CacheService.cs
+++ b/api-custom-events-and-metrics/Services/CacheService.cs
@@ -1,0 +1,47 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+
+namespace ApiCustomEventsAndMetrics.Services;
+
+/// <summary>
+/// A simple in-memory cache that demonstrates IncrementCounter for tracking
+/// cache hit/miss ratios.
+///
+/// IncrementCounter creates metric timeslices that increment by 1 per call. There
+/// is no "increment by N" variant — use RecordMetric for arbitrary numeric values.
+/// Counter names must start with "Custom/" for proper categorization.
+///
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#IncrementCounter
+/// </summary>
+public class CacheService
+{
+    private readonly ConcurrentDictionary<string, object> _cache = new();
+
+    /// <summary>
+    /// Retrieves a value from the cache, incrementing hit or miss counters.
+    /// </summary>
+    public object? Get(string key)
+    {
+        if (_cache.TryGetValue(key, out var value))
+        {
+            // Increment the cache hit counter. Each call increments by exactly 1.
+            NewRelic.Api.Agent.NewRelic.IncrementCounter("Custom/Cache/Hits");
+            return value;
+        }
+
+        // Increment the cache miss counter.
+        NewRelic.Api.Agent.NewRelic.IncrementCounter("Custom/Cache/Misses");
+        return null;
+    }
+
+    /// <summary>
+    /// Stores a value in the cache and increments the write counter.
+    /// </summary>
+    public void Set(string key, object value)
+    {
+        _cache[key] = value;
+        NewRelic.Api.Agent.NewRelic.IncrementCounter("Custom/Cache/Writes");
+    }
+}

--- a/api-custom-events-and-metrics/Services/CheckoutService.cs
+++ b/api-custom-events-and-metrics/Services/CheckoutService.cs
@@ -1,0 +1,93 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace ApiCustomEventsAndMetrics.Services;
+
+/// <summary>
+/// Demonstrates RecordCustomEvent and IncrementCounter for tracking business events
+/// and failure counts.
+///
+/// RecordCustomEvent creates individual queryable events (like database rows) with
+/// arbitrary attributes — ideal for business analytics where you need to filter and
+/// facet by specific values.
+///
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#RecordCustomEvent
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#IncrementCounter
+/// </summary>
+public class CheckoutService
+{
+    /// <summary>
+    /// Processes a checkout request. This method is called from a minimal API endpoint,
+    /// which means the ASP.NET Core auto-instrumentation already creates a transaction —
+    /// no [Transaction] attribute is needed.
+    ///
+    /// Demonstrates RecordCustomEvent for recording business-level event data with attributes.
+    /// </summary>
+    public IResult ProcessCheckout(CheckoutRequest request)
+    {
+        if (request.Items is null || request.Items.Count == 0)
+        {
+            RecordCheckoutFailure("EmptyCart");
+            return Results.BadRequest(new { error = "Cart is empty" });
+        }
+
+        if (request.TotalAmount <= 0)
+        {
+            RecordCheckoutFailure("InvalidAmount");
+            return Results.BadRequest(new { error = "Total amount must be greater than zero" });
+        }
+
+        // RecordCustomEvent creates an event row queryable via NRQL. Unlike metrics (which
+        // are pre-aggregated), custom events retain individual attribute values — you can
+        // filter, facet, and alert on any attribute. The event type name must not start with
+        // reserved prefixes and is limited to 255 characters.
+        // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#RecordCustomEvent
+        NewRelic.Api.Agent.NewRelic.RecordCustomEvent("CheckoutCompleted", new Dictionary<string, object>
+        {
+            { "customerId", request.CustomerId },
+            { "totalAmount", request.TotalAmount },
+            { "itemCount", request.Items.Count },
+            { "paymentMethod", request.PaymentMethod },
+            { "region", request.Region }
+        });
+
+        return Results.Ok(new
+        {
+            orderId = Guid.NewGuid().ToString("N")[..8],
+            status = "completed",
+            customerId = request.CustomerId,
+            totalAmount = request.TotalAmount
+        });
+    }
+
+    /// <summary>
+    /// Records a custom event and increments a counter for checkout failures.
+    ///
+    /// IncrementCounter increments by exactly 1 per call — there is no "increment by N"
+    /// variant. Use RecordMetric if you need to record a duration value.
+    ///
+    /// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#IncrementCounter
+    /// </summary>
+    private void RecordCheckoutFailure(string reason)
+    {
+        // IncrementCounter creates a metric timeslice that counts occurrences. The counter
+        // name must start with "Custom/". Useful for simple occurrence tracking without
+        // needing the full custom event payload.
+        NewRelic.Api.Agent.NewRelic.IncrementCounter("Custom/Checkout/Failures");
+
+        // Also record a custom event so we can query failures by reason, customer, etc.
+        NewRelic.Api.Agent.NewRelic.RecordCustomEvent("CheckoutFailed", new Dictionary<string, object>
+        {
+            { "reason", reason }
+        });
+    }
+}
+
+public record CheckoutRequest(
+    string CustomerId,
+    decimal TotalAmount,
+    List<CheckoutItem>? Items,
+    string PaymentMethod,
+    string Region);
+
+public record CheckoutItem(string ProductId, string Name, decimal Price, int Quantity);

--- a/api-custom-events-and-metrics/api-custom-events-and-metrics.csproj
+++ b/api-custom-events-and-metrics/api-custom-events-and-metrics.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>default</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Use the latest version of the NewRelic.Agent package.
+      NOTE: For a production app, you should always reference a specific package version
+    -->
+    <PackageReference Include="NewRelic.Agent" Version="*" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="*" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Adds a new `api-custom-events-and-metrics/` example application demonstrating `RecordCustomEvent`, `RecordMetric`, and `IncrementCounter`
- ASP.NET Core minimal API with a `POST /checkout` endpoint (custom events + failure counter), `GET /products/{id}` endpoint (cache hit/miss counters), and a `PeriodicMaintenanceService` background service (duration metric via `RecordMetric`)
- README includes verified NRQL query examples for both custom events and metric timeslice data, with a link to the timeslice query docs

## Test plan

- [ ] Set required environment variables and run `dotnet run -c Release --no-build` from `api-custom-events-and-metrics/`
- [ ] `POST /checkout` with a valid payload — verify `CheckoutCompleted` event appears in New Relic via `SELECT * FROM CheckoutCompleted SINCE 1 hour ago`
- [ ] `POST /checkout` with an empty items list — verify `CheckoutFailed` event and `Custom/Checkout/Failures` counter
- [ ] `GET /products/{id}` twice — verify `Custom/Cache/Misses` then `Custom/Cache/Hits` counters via the query builder
- [ ] Wait for `PeriodicMaintenanceService` to fire — verify `Custom/Maintenance/TaskDuration` metric appears
- [ ] `dotnet build` passes with 0 errors and 0 warnings on the new project