### PR TITLE
chore: Add Agent API dependency injection example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ App_Data
 # Docker env files
 *.env
 
+# User's Claude settings
+.claude
+
+
 
 
 

--- a/NewRelicDotNetExamples.sln
+++ b/NewRelicDotNetExamples.sln
@@ -106,6 +106,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "api-custom-events-and-metri
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api-custom-events-and-metrics", "api-custom-events-and-metrics\api-custom-events-and-metrics.csproj", "{E8A888FF-B716-49D9-8CEB-284F11170B09}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "kafka-custom-instrumentation", "kafka-custom-instrumentation", "{F1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5C}"
+	ProjectSection(SolutionItems) = preProject
+		kafka-custom-instrumentation\docker-compose.yml = kafka-custom-instrumentation\docker-compose.yml
+		kafka-custom-instrumentation\README.md = kafka-custom-instrumentation\README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kafka-custom-instrumentation", "kafka-custom-instrumentation\kafka-custom-instrumentation.csproj", "{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -308,6 +316,18 @@ Global
 		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Release|x64.Build.0 = Release|Any CPU
 		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Release|x86.ActiveCfg = Release|Any CPU
 		{E8A888FF-B716-49D9-8CEB-284F11170B09}.Release|x86.Build.0 = Release|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Debug|x86.Build.0 = Debug|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Release|x64.Build.0 = Release|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -338,6 +358,7 @@ Global
 		{1C903EA8-BC15-470A-AEDA-ED7CC7474BE9} = {A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D}
 		{1046409A-1E21-4FB3-8EFA-FFDC38B082D0} = {B2C3D4E5-F6A7-4B8C-9D0E-1F2A3B4C5D6E}
 		{E8A888FF-B716-49D9-8CEB-284F11170B09} = {E889351A-92EC-B9D4-C4E3-CC67B911FB4D}
+		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D} = {F1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {974824D6-453F-4962-AF8A-31949A0F847E}

--- a/NewRelicDotNetExamples.sln
+++ b/NewRelicDotNetExamples.sln
@@ -107,10 +107,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api-custom-events-and-metrics", "api-custom-events-and-metrics\api-custom-events-and-metrics.csproj", "{E8A888FF-B716-49D9-8CEB-284F11170B09}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "kafka-custom-instrumentation", "kafka-custom-instrumentation", "{F1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5C}"
-	ProjectSection(SolutionItems) = preProject
-		kafka-custom-instrumentation\docker-compose.yml = kafka-custom-instrumentation\docker-compose.yml
-		kafka-custom-instrumentation\README.md = kafka-custom-instrumentation\README.md
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kafka-custom-instrumentation", "kafka-custom-instrumentation\kafka-custom-instrumentation.csproj", "{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}"
 EndProject

--- a/NewRelicDotNetExamples.sln
+++ b/NewRelicDotNetExamples.sln
@@ -110,6 +110,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "kafka-custom-instrumentatio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kafka-custom-instrumentation", "kafka-custom-instrumentation\kafka-custom-instrumentation.csproj", "{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api-dependency-injection", "api-dependency-injection\api-dependency-injection.csproj", "{033B6AFD-A0C0-4500-A93A-27E64468D556}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -324,6 +326,18 @@ Global
 		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Release|x64.Build.0 = Release|Any CPU
 		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Release|x86.ActiveCfg = Release|Any CPU
 		{A1F2E3D4-C5B6-4A7F-8E9D-0C1B2A3F4E5D}.Release|x86.Build.0 = Release|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Debug|x64.Build.0 = Debug|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Debug|x86.Build.0 = Debug|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Release|Any CPU.Build.0 = Release|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Release|x64.ActiveCfg = Release|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Release|x64.Build.0 = Release|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Release|x86.ActiveCfg = Release|Any CPU
+		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/api-dependency-injection/Program.cs
+++ b/api-dependency-injection/Program.cs
@@ -1,0 +1,47 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using ApiDependencyInjection.Services;
+using NewRelic.Api.Agent;
+
+// Alias required because 'NewRelic' inside this file would otherwise resolve to the
+// root namespace. With the alias we can call the static NewRelic.Api.Agent.NewRelic
+// class unambiguously as NRAgent.
+using NRAgent = NewRelic.Api.Agent.NewRelic;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Register IAgent as a singleton using a factory that calls GetAgent() lazily.
+//
+// The factory defers the GetAgent() call until the container first resolves IAgent —
+// by which point the profiler has fully initialized the agent and GetAgent() returns
+// the live instance instead of the no-op placeholder it returns very early in startup.
+//
+// Singleton is correct: IAgent itself is a long-lived handle to the agent runtime and
+// is safe to share across threads and requests. What is NOT safe to share is any
+// request-scoped state fetched from IAgent (CurrentTransaction, CurrentSpan) —
+// see WorkService and AntiPatternExamples below for why.
+//
+// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#GetAgent
+builder.Services.AddSingleton<IAgent>(_ => NRAgent.GetAgent());
+
+// Services that consume IAgent via constructor injection. Any lifetime works here;
+// the important constraint is on how the service USES IAgent, not on how it's registered.
+builder.Services.AddSingleton<WorkService>();
+builder.Services.AddScoped<ScopedWorkService>();
+
+var app = builder.Build();
+
+app.Urls.Add("http://localhost:5004");
+
+// GET /work/singleton
+// Demonstrates the correct pattern: a singleton service with an injected IAgent that
+// fetches CurrentTransaction fresh inside each request-handling method.
+app.MapGet("/work/singleton", (WorkService service) => service.DoWork());
+
+// GET /work/scoped
+// Demonstrates a scoped service consuming the singleton IAgent. Scoped lifetime is a
+// natural fit for per-request services, but the IAgent registration is still singleton.
+app.MapGet("/work/scoped", (ScopedWorkService service) => service.DoWork());
+
+app.Run();

--- a/api-dependency-injection/README.md
+++ b/api-dependency-injection/README.md
@@ -1,0 +1,190 @@
+# New Relic .NET Agent API — Dependency Injection Example
+
+This example demonstrates the correct way to register and consume `IAgent` through
+Microsoft.Extensions.DependencyInjection, and documents the common anti-patterns
+that silently break telemetry.
+
+## The short version
+
+```csharp
+using NRAgent = NewRelic.Api.Agent.NewRelic;
+
+// ✅ Register IAgent as a singleton with a factory so GetAgent() is deferred
+builder.Services.AddSingleton<IAgent>(_ => NRAgent.GetAgent());
+```
+
+```csharp
+// ✅ Inject IAgent and fetch CurrentTransaction / CurrentSpan FRESH per call
+public class MyService
+{
+    private readonly IAgent _agent;
+
+    public MyService(IAgent agent) => _agent = agent;
+
+    public void DoWork()
+    {
+        var transaction = _agent.CurrentTransaction;  // request-scoped — local only
+        transaction.AddCustomAttribute("key", "value");
+    }
+}
+```
+
+## Why singleton is correct
+
+`IAgent` is a stateless handle to the agent runtime. The per-request state —
+`CurrentTransaction`, `CurrentSpan` — is stored in `AsyncLocal` under the hood, so
+the same `IAgent` instance correctly returns the current request's transaction to
+each caller. Registering `IAgent` as scoped or transient works but wastes
+allocations; there is no safety benefit.
+
+## Why the factory (`_ => NRAgent.GetAgent()`) matters
+
+`NewRelic.Api.Agent.NewRelic.GetAgent()` must be called AFTER the profiler has
+finished attaching. A factory lambda defers the call until the container first
+resolves `IAgent`, which happens on the first request — well after the profiler
+is ready. Resolving `GetAgent()` eagerly at registration time risks caching the
+no-op placeholder the API returns before the agent is live, silently disabling
+all custom instrumentation for the lifetime of the process.
+
+## The namespace alias
+
+`NewRelic.Api.Agent.NewRelic` is both a namespace prefix and a class name. Inside
+a file whose root namespace is `NewRelic.*`, the identifier `NewRelic` resolves
+to the namespace, not the class, and the compiler reports an error. Aliasing it:
+
+```csharp
+using NRAgent = NewRelic.Api.Agent.NewRelic;
+```
+
+...gives you an unambiguous name for the static class. This is only needed in
+files where the ambiguity exists; in most applications `NewRelic.Api.Agent.NewRelic.GetAgent()`
+works as written.
+
+## Anti-patterns — what NOT to do
+
+See [`Services/AntiPatternExamples.cs`](Services/AntiPatternExamples.cs) for
+compile-checked counter-examples. Summary:
+
+### ❌ Capturing `CurrentTransaction` in a field
+
+```csharp
+public class BuggyService
+{
+    private readonly ITransaction _transaction;
+
+    public BuggyService(IAgent agent)
+    {
+        _transaction = agent.CurrentTransaction; // ❌ wrong transaction forever
+    }
+}
+```
+
+For a singleton, the constructor runs during the first request. `_transaction`
+then holds that request's transaction permanently. Every subsequent call writes
+attributes, events, and errors to a transaction that has already ended — the
+data never appears on the transactions the user is actually looking at.
+
+### ❌ Capturing `CurrentSpan` in a field
+
+Same failure mode, one level deeper. A span belongs to a specific frame in a
+specific request and cannot be reused.
+
+### ❌ Resolving `GetAgent()` eagerly at registration time
+
+```csharp
+// ❌ Eager — GetAgent() runs while the container is being built
+builder.Services.AddSingleton<IAgent>(NewRelic.Api.Agent.NewRelic.GetAgent());
+
+// ✅ Lazy — GetAgent() runs on first resolution
+builder.Services.AddSingleton<IAgent>(_ => NewRelic.Api.Agent.NewRelic.GetAgent());
+```
+
+The eager form can capture the no-op placeholder that `GetAgent()` returns
+before the profiler has finished initializing and cache it as the singleton. The
+app then runs with a silently disabled API.
+
+## API surface covered
+
+| Type / Method | Documentation |
+|---|---|
+| `IAgent` | [IAgent](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#IAgent) |
+| `NewRelic.GetAgent()` | [GetAgent](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#GetAgent) |
+| `IAgent.CurrentTransaction` | [CurrentTransaction](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#CurrentTransaction) |
+| `ITransaction.CurrentSpan` | [CurrentSpan](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#CurrentSpan) |
+
+## How to run
+
+### Prerequisites
+
+- .NET 10 SDK
+- A New Relic account with a license key
+
+### NuGet packages
+
+- **`NewRelic.Agent`** — bundles the agent runtime (profiler, config, extensions) into the build output.
+- **`NewRelic.Agent.Api`** — provides the `IAgent`, `ITransaction`, and `ISpan` types used in this example.
+
+### Build and run
+
+**Windows (PowerShell):**
+
+```powershell
+dotnet build -c Release
+
+$env:CORECLR_ENABLE_PROFILING=1
+$env:CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+$env:CORECLR_PROFILER_PATH="$PWD\bin\Release\net10.0\newrelic\NewRelic.Profiler.dll"
+$env:CORECLR_NEWRELIC_HOME="$PWD\bin\Release\net10.0\newrelic"
+$env:NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+$env:NEW_RELIC_APP_NAME="api-dependency-injection-example"
+
+dotnet run -c Release --no-build
+```
+
+**Linux (bash):**
+
+```bash
+dotnet build -c Release
+
+export CORECLR_ENABLE_PROFILING=1
+export CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+export CORECLR_PROFILER_PATH="$PWD/bin/Release/net10.0/newrelic/libNewRelicProfiler.so"
+export CORECLR_NEWRELIC_HOME="$PWD/bin/Release/net10.0/newrelic"
+export NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+export NEW_RELIC_APP_NAME="api-dependency-injection-example"
+
+dotnet run -c Release --no-build
+```
+
+### Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /work/singleton` | Invokes `WorkService` (singleton) — writes an attribute to the current transaction via injected `IAgent`. |
+| `GET /work/scoped` | Invokes `ScopedWorkService` (scoped) consuming the same singleton `IAgent`. |
+
+### Example requests
+
+```bash
+curl http://localhost:5004/work/singleton
+curl http://localhost:5004/work/scoped
+```
+
+```powershell
+Invoke-RestMethod -Uri http://localhost:5004/work/singleton
+Invoke-RestMethod -Uri http://localhost:5004/work/scoped
+```
+
+## What to look for in New Relic
+
+Each request appears as its own transaction under the APM app, with its own
+custom attributes. Call each endpoint several times and confirm via NRQL that
+the `workService.lifetime` attribute varies per request — if it were captured
+in a field, every request past the first would show the same (stale) value.
+
+```sql
+SELECT workService.lifetime, workService.step
+FROM Transaction
+WHERE appName = 'api-dependency-injection-example'
+SINCE 10 minutes ago
+```

--- a/api-dependency-injection/Services/AntiPatternExamples.cs
+++ b/api-dependency-injection/Services/AntiPatternExamples.cs
@@ -1,0 +1,92 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Api.Agent;
+
+namespace ApiDependencyInjection.Services;
+
+// -----------------------------------------------------------------------------
+// DO NOT DO THIS
+//
+// The anti-patterns below are intentionally left UNREGISTERED with the DI
+// container and kept in this file purely as documented counter-examples. The
+// classes compile so that the exact shapes of the mistakes are visible, but
+// they are never instantiated by the running app.
+// -----------------------------------------------------------------------------
+
+/// <summary>
+/// ❌ ANTI-PATTERN: capturing <see cref="IAgent.CurrentTransaction"/> in a field.
+///
+/// Constructor injection runs once when the container first creates the service.
+/// For a singleton, that happens during the FIRST request. CurrentTransaction at
+/// that moment returns the transaction for request #1 — and every subsequent
+/// request that resolves this singleton will use that stale, request-#1
+/// transaction. Attributes, custom events, and errors get attached to a
+/// transaction that has long since ended, and no data appears on the transactions
+/// the user actually cares about.
+///
+/// Fix: store the IAgent, not the ITransaction. See <see cref="WorkService"/>.
+/// </summary>
+public class CapturedTransactionAntiPattern
+{
+    private readonly ITransaction _transaction;
+
+    public CapturedTransactionAntiPattern(IAgent agent)
+    {
+        // ❌ Captures a single request's transaction and reuses it forever.
+        _transaction = agent.CurrentTransaction;
+    }
+
+    public void DoWork()
+    {
+        _transaction.AddCustomAttribute("bug", "this attribute lands on the wrong transaction");
+    }
+}
+
+/// <summary>
+/// ❌ ANTI-PATTERN: capturing <see cref="ITransaction.CurrentSpan"/> in a field.
+///
+/// Same failure mode as <see cref="CapturedTransactionAntiPattern"/>, one level
+/// deeper: the span belongs to a specific frame within a specific request. It
+/// cannot be shared across requests or across unrelated method calls.
+/// </summary>
+public class CapturedSpanAntiPattern
+{
+    private readonly ISpan _span;
+
+    public CapturedSpanAntiPattern(IAgent agent)
+    {
+        // ❌ Captures a single request's span and reuses it forever.
+        _span = agent.CurrentTransaction.CurrentSpan;
+    }
+
+    public void DoWork()
+    {
+        _span.AddCustomAttribute("bug", "this attribute lands on the wrong span");
+    }
+}
+
+/// <summary>
+/// ❌ ANTI-PATTERN: calling <c>NewRelic.Api.Agent.NewRelic.GetAgent()</c> at
+/// registration time instead of inside a factory.
+///
+/// The commented registration below resolves GetAgent() eagerly while the DI
+/// container is being built. On some hosting models the profiler has not yet
+/// finished attaching at that moment, so GetAgent() returns a no-op placeholder
+/// that gets cached as the singleton forever. The app then runs with a silently
+/// disabled API surface and no data reaches New Relic.
+///
+/// Fix: use a factory lambda so GetAgent() is deferred until first resolution —
+/// see Program.cs.
+/// <code>
+/// // ❌ DO NOT DO THIS — eager resolution at registration time
+/// builder.Services.AddSingleton<IAgent>(NewRelic.Api.Agent.NewRelic.GetAgent());
+///
+/// // ✅ DO THIS — factory defers GetAgent() until first resolution
+/// builder.Services.AddSingleton<IAgent>(_ => NewRelic.Api.Agent.NewRelic.GetAgent());
+/// </code>
+/// </summary>
+internal static class EagerRegistrationAntiPatternDoc
+{
+    // Intentionally empty — documentation only.
+}

--- a/api-dependency-injection/Services/WorkService.cs
+++ b/api-dependency-injection/Services/WorkService.cs
@@ -1,0 +1,76 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Api.Agent;
+
+namespace ApiDependencyInjection.Services;
+
+/// <summary>
+/// Demonstrates the correct way to use a DI-injected <see cref="IAgent"/> from a
+/// singleton service.
+///
+/// The rule: inject IAgent once and keep it in a field, but fetch
+/// <see cref="IAgent.CurrentTransaction"/> and <see cref="ITransaction.CurrentSpan"/>
+/// fresh on every method call. Those properties return the transaction and span for
+/// the CURRENT request — capturing them in a field would poison every subsequent
+/// request that resolves this singleton.
+///
+/// Because this method is invoked from an ASP.NET Core minimal API endpoint, the
+/// agent's built-in auto-instrumentation has already created a transaction for the
+/// request. Inside DoWork the agent's notion of "current transaction" is the one
+/// tied to the currently-executing request, carried via AsyncLocal under the hood.
+/// </summary>
+public class WorkService
+{
+    private readonly IAgent _agent;
+
+    public WorkService(IAgent agent)
+    {
+        _agent = agent;
+    }
+
+    public IResult DoWork()
+    {
+        // Fetch CurrentTransaction FRESH here — do not cache this value in a field.
+        // Each request gets its own transaction; the AsyncLocal context on this call
+        // resolves to the transaction for THIS request.
+        var transaction = _agent.CurrentTransaction;
+        transaction.AddCustomAttribute("workService.lifetime", "singleton");
+
+        // Same rule applies to CurrentSpan — fetch it per method call.
+        var span = transaction.CurrentSpan;
+        span.AddCustomAttribute("workService.step", "DoWork");
+
+        return Results.Ok(new { message = "Work completed (singleton service)" });
+    }
+}
+
+/// <summary>
+/// Demonstrates that the rule is about USAGE, not the consuming service's lifetime.
+/// A scoped service consuming the singleton IAgent must still fetch CurrentTransaction
+/// per method call.
+///
+/// A scoped service is created once per request, so in theory capturing
+/// CurrentTransaction in a field at construction would be safe here. In practice we
+/// still don't do that, because (a) it would diverge from the singleton pattern and
+/// invite the bug if someone later changes the registration to singleton, and (b) any
+/// method called outside an active transaction (e.g. during shutdown) would see a
+/// stale reference.
+/// </summary>
+public class ScopedWorkService
+{
+    private readonly IAgent _agent;
+
+    public ScopedWorkService(IAgent agent)
+    {
+        _agent = agent;
+    }
+
+    public IResult DoWork()
+    {
+        var transaction = _agent.CurrentTransaction;
+        transaction.AddCustomAttribute("workService.lifetime", "scoped");
+
+        return Results.Ok(new { message = "Work completed (scoped service)" });
+    }
+}

--- a/api-dependency-injection/api-dependency-injection.csproj
+++ b/api-dependency-injection/api-dependency-injection.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>default</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>ApiDependencyInjection</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Use the latest version of the NewRelic.Agent package.
+      NOTE: For a production app, you should always reference a specific package version
+    -->
+    <PackageReference Include="NewRelic.Agent" Version="*" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="*" />
+  </ItemGroup>
+
+</Project>

--- a/kafka-custom-instrumentation/Program.cs
+++ b/kafka-custom-instrumentation/Program.cs
@@ -1,0 +1,55 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using KafkaCustomInstrumentation.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var bootstrapServers = Environment.GetEnvironmentVariable("KAFKA_BOOTSTRAP_SERVERS") ?? "localhost:9092";
+
+// KafkaProducerService is a singleton because IProducer<> is thread-safe and intended
+// to be shared across requests for the lifetime of the application.
+builder.Services.AddSingleton(_ => new KafkaProducerService(bootstrapServers));
+
+// Both consumer services are long-running background workers. Factory lambdas are used
+// here because the services take a plain string (bootstrapServers) alongside the
+// DI-provided ILogger<T>, which requires manual wiring.
+builder.Services.AddHostedService(sp =>
+    new ConsumeToCompleteConsumerService(
+        bootstrapServers,
+        sp.GetRequiredService<ILogger<ConsumeToCompleteConsumerService>>()));
+
+builder.Services.AddHostedService(sp =>
+    new ProcessingOnlyConsumerService(
+        bootstrapServers,
+        sp.GetRequiredService<ILogger<ProcessingOnlyConsumerService>>()));
+
+var app = builder.Build();
+
+app.Urls.Add("http://localhost:5004");
+
+// POST /consume-to-complete/produce
+// Sends a message to the consume-to-complete topic. The ConsumeToCompleteConsumerService
+// receives these messages inside a [Transaction]-decorated method, which enables the
+// agent's Kafka auto-instrumentation of consumer.Consume() — creating a MessageBroker
+// segment and automatically accepting distributed trace headers. The resulting transaction
+// duration spans from consume to end of processing.
+app.MapPost("/consume-to-complete/produce", async (HttpRequest request, KafkaProducerService producer) =>
+{
+    var message = await new StreamReader(request.Body).ReadToEndAsync();
+    await producer.ProduceConsumeToCompleteMessageAsync(message);
+    return Results.Ok(new { topic = KafkaProducerService.ConsumeToCompleteTopic, message });
+});
+
+// POST /processing-only/produce
+// Sends a message to the processing-only topic. The ProcessingOnlyConsumerService calls
+// Consume() outside any transaction so the transaction duration reflects only the
+// processing work. Distributed trace headers must be accepted manually inside ProcessMessage().
+app.MapPost("/processing-only/produce", async (HttpRequest request, KafkaProducerService producer) =>
+{
+    var message = await new StreamReader(request.Body).ReadToEndAsync();
+    await producer.ProduceProcessingOnlyMessageAsync(message);
+    return Results.Ok(new { topic = KafkaProducerService.ProcessingOnlyTopic, message });
+});
+
+app.Run();

--- a/kafka-custom-instrumentation/README.md
+++ b/kafka-custom-instrumentation/README.md
@@ -1,0 +1,219 @@
+# New Relic .NET Agent — Kafka Custom Instrumentation Example
+
+This example demonstrates how transaction placement — where you open a New Relic transaction relative to the Kafka `Consume()` call — determines what gets measured in APM. Two patterns are shown: one where the transaction spans the full message lifecycle from consume to completion, and one where the transaction covers only the processing work.
+
+## API Methods Covered
+
+| Method | Documentation |
+|--------|---------------|
+| `[Transaction]` attribute | [Custom instrumentation via attributes](https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) |
+| `[Trace]` attribute | [Custom instrumentation via attributes](https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) |
+| `ITransaction.InsertDistributedTraceHeaders()` | [InsertDistributedTraceHeaders](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#InsertDistributedTraceHeaders) |
+| `ITransaction.AcceptDistributedTraceHeaders()` | [AcceptDistributedTraceHeaders](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AcceptDistributedTraceHeaders) |
+| `NewRelic.SetTransactionName()` | [SetTransactionName](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetTransactionName) |
+| `NewRelic.IgnoreTransaction()` | [IgnoreTransaction](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#IgnoreTransaction) |
+| `ITransaction.AddCustomAttribute()` | [AddCustomAttribute](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction.AddCustomAttribute) |
+
+## Key Concepts Demonstrated
+
+### Transaction Placement and What It Measures
+
+The .NET agent can automatically instrument calls to `consumer.Consume()` from the Confluent.Kafka client, but only when the call is made from inside an active transaction. When `Consume()` runs inside a transaction, the agent:
+
+- Creates a **MessageBroker segment** in the APM trace timeline, showing the consume step as a distinct span
+- **Automatically accepts** any New Relic distributed trace headers present in the message, linking the consumer transaction to the upstream producer
+
+When `Consume()` runs outside a transaction, neither of those things happens. The choice of where to open the transaction therefore determines both what the transaction duration measures and what appears in the trace timeline.
+
+### Pattern 1: Consume-to-Complete (`ConsumeToCompleteConsumerService`)
+
+Use this pattern when you want APM to show both the consume step and the processing step as distinct segments in the same transaction — for example, when you want to see how much of a transaction's duration is spent in the Confluent.Kafka `Consume()` call versus in your own processing code.
+
+Note that the transaction duration includes the time `Consume()` spent polling (up to the 200ms timeout), not the time the message spent waiting in the Kafka queue before this poll. True produce-to-consume queue latency is not captured in the transaction duration. It is, however, visible indirectly: because distributed trace headers are automatically accepted from the message, the producer HTTP transaction and this consumer transaction are linked in New Relic's distributed tracing view. You can inspect individual traces to see the wall-clock gap between the producer span and the consumer span, but this is not automatically aggregated as a metric.
+
+The structure:
+
+```
+ExecuteAsync() — tight loop, no transaction
+  └─ ConsumeAndProcess()  [Transaction]  ← transaction opens here, before Consume()
+       └─ consumer.Consume()             ← auto-instrumented: MessageBroker segment created,
+       │                                    DT headers accepted automatically
+       └─ ProcessMessage()  [Trace]      ← child span for processing work
+```
+
+Because `ConsumeAndProcess()` is decorated with `[Transaction]`, a transaction is active when `Consume()` executes. When no message arrives within the poll timeout, `IgnoreTransaction()` discards the empty transaction so that idle polling cycles do not appear in New Relic.
+
+The transaction duration includes both the time `Consume()` took (up to the 200ms poll timeout) and the time `ProcessMessage()` took. In the APM trace timeline you will see a `MessageBroker/Kafka/Topic/Consume/Named/consume-to-complete-messages` segment followed by the `ProcessMessage` segment.
+
+### Pattern 2: Processing-Only (`ProcessingOnlyConsumerService`)
+
+Use this pattern when **the consumer acts as a trigger for work** and you want APM to reflect the cost of that work — for example, when a message kicks off a report generation job or an ETL pipeline and you want to measure how long the job takes, independent of how long the consumer polled before the message arrived.
+
+The structure:
+
+```
+ExecuteAsync() — loop, no transaction
+  └─ consumer.Consume(stoppingToken)    ← NOT instrumented: no transaction active,
+  │                                        blocks until a message arrives
+  └─ ProcessMessage()  [Transaction]    ← transaction opens only when a message exists;
+       │                                   duration = processing cost only
+       └─ AcceptDistributedTraceHeaders()  ← must be called manually (the agent did not
+       │                                      intercept Consume(), so it did not do this)
+       └─ SetTransactionName()          ← must be called explicitly (no MessageBroker
+                                           segment to derive a name from)
+```
+
+Because `Consume()` ran outside a transaction, the agent never saw the call and did not accept the distributed trace headers. `AcceptDistributedTraceHeaders()` must be called manually at the start of `ProcessMessage()` to establish the link back to the producer. Without it, the consumer transaction appears isolated in New Relic with no connection to the trace that produced the message.
+
+The transaction duration reflects only the actual processing work, regardless of how long the consumer polled before the message arrived.
+
+### Producer: Injecting Distributed Trace Headers
+
+Both produce endpoints are auto-instrumented by the agent as ASP.NET Core web transactions. `KafkaProducerService.ProduceWithTraceHeadersAsync()` calls `InsertDistributedTraceHeaders()` to write the current transaction's trace context into the Kafka message headers as UTF-8 byte arrays. This connects the producer-side HTTP transaction to the consumer-side transaction in New Relic's distributed tracing view.
+
+### `IgnoreTransaction()` for Empty Polling Cycles (Pattern 1 Only)
+
+In Pattern 1, `ConsumeAndProcess()` opens a `[Transaction]` before every `Consume()` call, including calls that return null (no message within the timeout). `IgnoreTransaction()` tells the agent to discard the current transaction and not report it to New Relic. This keeps the APM transaction list clean — only message-processing transactions appear, not empty polling cycles.
+
+## NuGet Packages
+
+- **`Confluent.Kafka`** — The official .NET client for Apache Kafka. Provides `IProducer<>`, `IConsumer<>`, and related types.
+- **`NewRelic.Agent`** — Bundles the agent runtime files (profiler, configuration, extensions) into the build output directory.
+- **`NewRelic.Agent.Api`** — Provides the `NewRelic.Api.Agent` namespace used throughout this example.
+
+## Prerequisites
+
+- .NET 10 SDK
+- Docker (for the local Kafka broker)
+- A New Relic account with a license key
+
+## How to Run
+
+### 1. Start Kafka
+
+Start a local single-node Kafka broker using the provided `docker-compose.yml`:
+
+```bash
+docker compose up -d
+```
+
+The broker listens on `localhost:9092`. To stop it later: `docker compose down`.
+
+### 2. Run the Application
+
+This example uses the `NewRelic.Agent` NuGet package, which places the agent files under the build output directory. You must set several [environment variables](https://docs.newrelic.com/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/) to enable the .NET CLR profiler and point it to the agent.
+
+**Windows (PowerShell):**
+
+```powershell
+# Build first so the agent files are in the output directory
+dotnet build -c Release
+
+# Set the required environment variables for the .NET agent
+$env:CORECLR_ENABLE_PROFILING=1
+$env:CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+$env:CORECLR_PROFILER_PATH="$PWD\bin\Release\net10.0\newrelic\NewRelic.Profiler.dll"
+$env:CORECLR_NEWRELIC_HOME="$PWD\bin\Release\net10.0\newrelic"
+$env:NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+$env:NEW_RELIC_APP_NAME="kafka-custom-instrumentation-example"
+
+# Run the application
+dotnet run -c Release --no-build
+```
+
+**Linux (bash):**
+
+```bash
+# Build first so the agent files are in the output directory
+dotnet build -c Release
+
+# Set the required environment variables for the .NET agent
+export CORECLR_ENABLE_PROFILING=1
+export CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+export CORECLR_PROFILER_PATH="$PWD/bin/Release/net10.0/newrelic/libNewRelicProfiler.so"
+export CORECLR_NEWRELIC_HOME="$PWD/bin/Release/net10.0/newrelic"
+export NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+export NEW_RELIC_APP_NAME="kafka-custom-instrumentation-example"
+
+# Run the application
+dotnet run -c Release --no-build
+```
+
+| Variable | Purpose |
+|----------|---------|
+| `CORECLR_ENABLE_PROFILING` | Enables the .NET CLR profiler (must be `1`) |
+| `CORECLR_PROFILER` | The CLSID of the New Relic profiler |
+| `CORECLR_PROFILER_PATH` | Path to the profiler native library (`NewRelic.Profiler.dll` on Windows, `libNewRelicProfiler.so` on Linux) |
+| `CORECLR_NEWRELIC_HOME` | Path to the directory containing the agent configuration and extensions |
+| `NEW_RELIC_LICENSE_KEY` | Your New Relic license key |
+| `NEW_RELIC_APP_NAME` | The application name as it will appear in New Relic |
+| `KAFKA_BOOTSTRAP_SERVERS` | (Optional) Kafka bootstrap servers. Defaults to `localhost:9092` |
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/consume-to-complete/produce` | POST | Sends a message to the consume-to-complete topic. The consumer's transaction spans from `Consume()` to end of processing; transaction duration includes both consume time and processing time. |
+| `/processing-only/produce` | POST | Sends a message to the processing-only topic. The consumer's transaction opens only when a message arrives; transaction duration reflects processing cost only. |
+
+Both endpoints inject distributed trace headers into the message before producing, so the producer HTTP transaction and consumer transaction appear as a linked distributed trace in New Relic.
+
+## Example Requests
+
+**Linux (bash):**
+
+```bash
+# Pattern 1 (consume-to-complete): Consume() is called inside a [Transaction], so the
+# agent auto-instruments it. The transaction duration includes both the Consume() poll
+# time and the processing time, and a MessageBroker segment appears in the APM trace.
+curl -X POST http://localhost:5004/consume-to-complete/produce \
+  -H "Content-Type: text/plain" \
+  -d "order-12345 ready for fulfillment"
+
+# Pattern 2 (processing-only): Consume() is called outside any transaction, so the agent
+# does not instrument it. The transaction opens only when a message arrives and covers
+# processing time only. Distributed trace headers are accepted manually in ProcessMessage().
+curl -X POST http://localhost:5004/processing-only/produce \
+  -H "Content-Type: text/plain" \
+  -d "generate monthly report for account 9876"
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Pattern 1 (consume-to-complete): Consume() is called inside a [Transaction], so the
+# agent auto-instruments it. The transaction duration includes both the Consume() poll
+# time and the processing time, and a MessageBroker segment appears in the APM trace.
+Invoke-RestMethod -Method POST -Uri http://localhost:5004/consume-to-complete/produce `
+  -ContentType "text/plain" `
+  -Body "order-12345 ready for fulfillment"
+
+# Pattern 2 (processing-only): Consume() is called outside any transaction, so the agent
+# does not instrument it. The transaction opens only when a message arrives and covers
+# processing time only. Distributed trace headers are accepted manually in ProcessMessage().
+Invoke-RestMethod -Method POST -Uri http://localhost:5004/processing-only/produce `
+  -ContentType "text/plain" `
+  -Body "generate monthly report for account 9876"
+```
+
+## What to Look For
+
+### APM Transactions
+
+After sending requests, navigate to **APM > (your app) > Transactions** to find the two consumer transaction types.
+
+**Pattern 1 — Consume-to-Complete** transactions are named `OtherTransaction/Kafka/ConsumeToComplete/consume-to-complete-messages`. Open one in the trace details — you will see a `MessageBroker/Kafka/Topic/Consume/Named/consume-to-complete-messages` segment followed by the `ProcessMessage` segment. The transaction duration includes both.
+
+**Pattern 2 — Processing-Only** transactions are named `OtherTransaction/Kafka/ProcessingOnly/processing-only-messages`. Open one in the trace details — there is no MessageBroker segment because `Consume()` was not instrumented. The transaction duration reflects only the processing work.
+
+Because Pattern 1 transactions include the `Consume()` poll window (up to 200ms) while Pattern 2 transactions do not, their average durations will differ even when the underlying processing work is similar. This difference illustrates the core tradeoff: Pattern 1 duration includes poll time plus processing time — not queue latency. Pattern 2 duration reflects only processing cost.
+
+### Custom Attributes
+
+Both consumers add Kafka delivery metadata as custom attributes on each transaction: `kafka.topic`, `kafka.partition`, `kafka.offset`, and `kafka.message.key`. These are visible in the transaction attributes panel in APM.
+
+### Distributed Tracing
+
+Each produce endpoint call generates one HTTP transaction (the producer) and one Kafka consumer transaction. Both carry the same trace ID and appear as a single connected trace in New Relic's distributed tracing view.
+
+Navigate to **APM > (your app) > Distributed tracing** and select a trace that includes both an HTTP span (the producer endpoint) and a Kafka consumer span. In Pattern 1, the consumer span will have a `MessageBroker` child segment. In Pattern 2, it will not — but both traces will show the full producer-to-consumer link because distributed trace headers were accepted in both cases (automatically in Pattern 1, manually via `AcceptDistributedTraceHeaders()` in Pattern 2).

--- a/kafka-custom-instrumentation/Services/ConsumeToCompleteConsumerService.cs
+++ b/kafka-custom-instrumentation/Services/ConsumeToCompleteConsumerService.cs
@@ -12,9 +12,7 @@ namespace KafkaCustomInstrumentation.Services;
 /// lifecycle from the Consume() call to the end of processing.
 ///
 /// Use this pattern when consume lag is itself a KPI — for example, when your SLA
-/// requires that messages are fully processed within N seconds of being produced, or
-/// when you want APM to show both how long a message waited in the queue and how long
-/// processing took, as two segments in the same transaction.
+/// requires that messages are fully processed within N seconds of being produced.
 ///
 /// The key requirement for the .NET agent to auto-instrument consumer.Consume() is that
 /// it must be called from inside an active transaction. In this pattern, ConsumeAndProcess()

--- a/kafka-custom-instrumentation/Services/ConsumeToCompleteConsumerService.cs
+++ b/kafka-custom-instrumentation/Services/ConsumeToCompleteConsumerService.cs
@@ -1,0 +1,152 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+using Confluent.Kafka;
+using NewRelic.Api.Agent;
+
+namespace KafkaCustomInstrumentation.Services;
+
+/// <summary>
+/// Demonstrates Pattern 1: a consumer where the transaction spans the full message
+/// lifecycle from the Consume() call to the end of processing.
+///
+/// Use this pattern when consume lag is itself a KPI — for example, when your SLA
+/// requires that messages are fully processed within N seconds of being produced, or
+/// when you want APM to show both how long a message waited in the queue and how long
+/// processing took, as two segments in the same transaction.
+///
+/// The key requirement for the .NET agent to auto-instrument consumer.Consume() is that
+/// it must be called from inside an active transaction. In this pattern, ConsumeAndProcess()
+/// is decorated with [Transaction], so a transaction is already open when Consume() executes.
+/// The agent intercepts that call to:
+///   - Create a MessageBroker segment (visible in the APM trace timeline)
+///   - Automatically accept any distributed trace headers present in the message
+///
+/// If Consume() were called outside a transaction (as in the processing-only pattern),
+/// neither of those things would happen.
+///
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/
+/// </summary>
+public class ConsumeToCompleteConsumerService : BackgroundService
+{
+    private const string TopicName = KafkaProducerService.ConsumeToCompleteTopic;
+    private const string ConsumerGroup = "consume-to-complete-consumer-group";
+
+    private readonly IConsumer<string, string> _consumer;
+    private readonly ILogger<ConsumeToCompleteConsumerService> _logger;
+
+    public ConsumeToCompleteConsumerService(string bootstrapServers, ILogger<ConsumeToCompleteConsumerService> logger)
+    {
+        _logger = logger;
+
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = bootstrapServers,
+            GroupId = ConsumerGroup,
+            AutoOffsetReset = AutoOffsetReset.Earliest
+        };
+        _consumer = new ConsumerBuilder<string, string>(config).Build();
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        return Task.Run(() =>
+        {
+            _consumer.Subscribe(TopicName);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    // ConsumeAndProcess() opens a [Transaction] before calling Consume().
+                    // The transaction being active is what enables the agent's Kafka
+                    // auto-instrumentation of the Consume() call inside that method.
+                    ConsumeAndProcess();
+                }
+                catch (ConsumeException ex)
+                {
+                    // Transient broker errors (e.g., topic not yet created) should not
+                    // crash the service. Log and retry after a brief delay.
+                    _logger.LogWarning("[ConsumeToComplete] Consume error: {Reason}. Retrying in 2s.", ex.Error.Reason);
+                    Thread.Sleep(2000);
+                }
+            }
+        }, stoppingToken);
+    }
+
+    /// <summary>
+    /// Opens a transaction, calls Consume(), and — when a message is available —
+    /// processes it. The [Transaction] attribute ensures the agent has an active
+    /// transaction when Consume() executes, which is the prerequisite for Kafka
+    /// auto-instrumentation to fire.
+    ///
+    /// When Consume() returns null (no message within the timeout), IgnoreTransaction()
+    /// discards the transaction so that empty polling cycles do not appear in New Relic.
+    ///
+    /// [MethodImpl(MethodImplOptions.NoInlining)] prevents the JIT from inlining this
+    /// method into the call site, which would remove the method boundary the agent
+    /// relies on to apply the [Transaction] attribute.
+    ///
+    /// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#IgnoreTransaction
+    /// </summary>
+    [Transaction]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ConsumeAndProcess()
+    {
+        // Consume() is called here, inside an active [Transaction]. The agent intercepts
+        // this call to create a MessageBroker segment and to accept any distributed trace
+        // headers present in the message — the same result as calling
+        // AcceptDistributedTraceHeaders() manually in Pattern 2, but automatic.
+        var result = _consumer.Consume(TimeSpan.FromMilliseconds(200));
+
+        if (result == null)
+        {
+            // No message arrived within the timeout. Discard this transaction so that
+            // empty polling cycles do not appear in New Relic APM or affect metrics.
+            // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#IgnoreTransaction
+            NewRelic.Api.Agent.NewRelic.IgnoreTransaction();
+            return;
+        }
+
+        // Name the transaction so it is easy to identify in the APM UI and NRQL queries.
+        // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetTransactionName
+        NewRelic.Api.Agent.NewRelic.SetTransactionName("Kafka", $"ConsumeToComplete/{TopicName}");
+
+        ProcessMessage(result);
+    }
+
+    /// <summary>
+    /// Processes an individual message as a child span of the ConsumeAndProcess()
+    /// transaction. [Trace] creates a separate segment in the APM trace timeline,
+    /// making it easy to see how processing time compares to consume time.
+    /// </summary>
+    [Trace]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProcessMessage(ConsumeResult<string, string> result)
+    {
+        var transaction = NewRelic.Api.Agent.NewRelic.GetAgent().CurrentTransaction;
+
+        // Add Kafka delivery metadata as custom attributes so they are queryable in NRQL.
+        // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction.AddCustomAttribute
+        transaction
+            .AddCustomAttribute("kafka.topic", result.Topic)
+            .AddCustomAttribute("kafka.partition", result.Partition.Value)
+            .AddCustomAttribute("kafka.offset", result.Offset.Value)
+            .AddCustomAttribute("kafka.message.key", result.Message.Key ?? "(null)");
+
+        // Simulate processing work.
+        Thread.Sleep(Random.Shared.Next(250, 1000));
+
+        _logger.LogInformation(
+            "[ConsumeToComplete] Processed message on {Topic} [{Partition}@{Offset}]: {Value}",
+            result.Topic, result.Partition.Value, result.Offset.Value, result.Message.Value);
+    }
+
+    public override void Dispose()
+    {
+        _consumer.Close();
+        _consumer.Dispose();
+        base.Dispose();
+    }
+}

--- a/kafka-custom-instrumentation/Services/KafkaProducerService.cs
+++ b/kafka-custom-instrumentation/Services/KafkaProducerService.cs
@@ -1,0 +1,70 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text;
+using Confluent.Kafka;
+
+namespace KafkaCustomInstrumentation.Services;
+
+/// <summary>
+/// Produces messages to the consume-to-complete and processing-only Kafka topics,
+/// injecting New Relic distributed trace headers into each message.
+///
+/// Both produce methods are invoked from ASP.NET Core endpoints, which the agent
+/// auto-instruments as web transactions. This means a transaction is already active
+/// when InsertDistributedTraceHeaders is called, so the outbound headers carry a valid
+/// trace context that the consumer can use to link its transaction back to this one.
+///
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#InsertDistributedTraceHeaders
+/// </summary>
+public class KafkaProducerService
+{
+    public const string ConsumeToCompleteTopic = "consume-to-complete-messages";
+    public const string ProcessingOnlyTopic = "processing-only-messages";
+
+    private readonly IProducer<string, string> _producer;
+
+    public KafkaProducerService(string bootstrapServers)
+    {
+        var config = new ProducerConfig { BootstrapServers = bootstrapServers };
+        _producer = new ProducerBuilder<string, string>(config).Build();
+    }
+
+    public Task ProduceConsumeToCompleteMessageAsync(string payload) =>
+        ProduceWithTraceHeadersAsync(ConsumeToCompleteTopic, payload);
+
+    public Task ProduceProcessingOnlyMessageAsync(string payload) =>
+        ProduceWithTraceHeadersAsync(ProcessingOnlyTopic, payload);
+
+    /// <summary>
+    /// Injects distributed trace headers into the Kafka message before producing. The
+    /// delegate receives the Kafka Headers collection as the carrier and adds each header
+    /// as a UTF-8 byte array. On the consumer side, the headers are extracted and passed
+    /// to AcceptDistributedTraceHeaders() — either automatically by the agent (Pattern 1)
+    /// or manually in code (Pattern 2).
+    ///
+    /// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#InsertDistributedTraceHeaders
+    /// </summary>
+    private async Task ProduceWithTraceHeadersAsync(string topic, string payload)
+    {
+        var headers = new Headers();
+
+        // Inject the current transaction's distributed trace context into the message
+        // headers. The lambda receives the Headers collection as the carrier, plus the
+        // key and value to add. Values are stored as UTF-8 bytes (Kafka header values
+        // have no implied encoding, so UTF-8 is the conventional choice).
+        NewRelic.Api.Agent.NewRelic.GetAgent().CurrentTransaction
+            .InsertDistributedTraceHeaders(
+                headers,
+                (carrier, key, value) => carrier.Add(key, Encoding.UTF8.GetBytes(value)));
+
+        var message = new Message<string, string>
+        {
+            Key = Guid.NewGuid().ToString(),
+            Value = payload,
+            Headers = headers
+        };
+
+        await _producer.ProduceAsync(topic, message);
+    }
+}

--- a/kafka-custom-instrumentation/Services/ProcessingOnlyConsumerService.cs
+++ b/kafka-custom-instrumentation/Services/ProcessingOnlyConsumerService.cs
@@ -1,0 +1,162 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using Confluent.Kafka;
+using NewRelic.Api.Agent;
+
+namespace KafkaCustomInstrumentation.Services;
+
+/// <summary>
+/// Demonstrates Pattern 2: a consumer where the transaction covers only the processing
+/// work, not the time spent waiting for a message to arrive.
+///
+/// Use this pattern when the consumer acts as a trigger for work and you want APM to
+/// reflect the cost of that work — for example, when a message kicks off a report
+/// generation job or an ETL pipeline and you want to measure how long the job takes,
+/// independent of how long the consumer polled before the message arrived.
+///
+/// In this pattern, consumer.Consume() is called OUTSIDE any transaction. As a result:
+///   - The agent does NOT auto-instrument Consume(): no MessageBroker segment is created.
+///   - Incoming distributed trace headers are NOT automatically accepted.
+///
+/// A [Transaction] is opened only when a message actually arrives, in ProcessMessage().
+/// Because the agent never intercepted the Consume() call, AcceptDistributedTraceHeaders()
+/// must be called manually to link this transaction back to the upstream producer trace.
+///
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/
+/// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AcceptDistributedTraceHeaders
+/// </summary>
+public class ProcessingOnlyConsumerService : BackgroundService
+{
+    private const string TopicName = KafkaProducerService.ProcessingOnlyTopic;
+    private const string ConsumerGroup = "processing-only-consumer-group";
+
+    private readonly IConsumer<string, string> _consumer;
+    private readonly ILogger<ProcessingOnlyConsumerService> _logger;
+
+    public ProcessingOnlyConsumerService(string bootstrapServers, ILogger<ProcessingOnlyConsumerService> logger)
+    {
+        _logger = logger;
+
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = bootstrapServers,
+            GroupId = ConsumerGroup,
+            AutoOffsetReset = AutoOffsetReset.Earliest
+        };
+        _consumer = new ConsumerBuilder<string, string>(config).Build();
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        return Task.Run(() =>
+        {
+            _consumer.Subscribe(TopicName);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    // Consume() is called here, OUTSIDE any transaction. This is intentional:
+                    // the transaction duration should reflect the cost of processing work, not
+                    // the time spent waiting for a message. The call blocks until a message
+                    // arrives or the cancellation token is signalled.
+                    //
+                    // Because no transaction is active, the agent will NOT create a
+                    // MessageBroker segment and will NOT accept distributed trace headers.
+                    // Both must be handled manually inside ProcessMessage().
+                    var result = _consumer.Consume(stoppingToken);
+                    ProcessMessage(result);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ConsumeException ex)
+                {
+                    // Transient broker errors (e.g., topic not yet created) should not
+                    // crash the service. Log and retry after a brief delay.
+                    _logger.LogWarning("[ProcessingOnly] Consume error: {Reason}. Retrying in 2s.", ex.Error.Reason);
+                    Thread.Sleep(2000);
+                }
+            }
+        }, stoppingToken);
+    }
+
+    /// <summary>
+    /// Creates a transaction scoped to the processing of a single message. Because
+    /// Consume() ran outside a transaction, two things that would otherwise be automatic
+    /// must be done manually:
+    ///
+    ///   1. AcceptDistributedTraceHeaders() — links this transaction back to the producer's
+    ///      trace in New Relic's distributed tracing view. Without this call the consumer
+    ///      transaction appears as an isolated, unconnected transaction.
+    ///
+    ///   2. SetTransactionName() — gives the transaction a meaningful name. In Pattern 1
+    ///      the MessageBroker segment makes the transaction identifiable; here there is no
+    ///      such segment, so an explicit name is required.
+    ///
+    /// [Transaction] + [MethodImpl(MethodImplOptions.NoInlining)] ensure the agent creates
+    /// a new transaction for each message and that the method boundary is preserved.
+    ///
+    /// See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AcceptDistributedTraceHeaders
+    /// </summary>
+    [Transaction]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ProcessMessage(ConsumeResult<string, string> result)
+    {
+        var transaction = NewRelic.Api.Agent.NewRelic.GetAgent().CurrentTransaction;
+
+        // Manually accept the distributed trace headers from the Kafka message. The getter
+        // delegate receives the Headers collection and the header key to look up, returning
+        // the matching value as a string array (or null if the key is absent).
+        //
+        // This is the step the agent performs automatically in Pattern 1 when Consume() is
+        // called inside a transaction. Without this call, no distributed tracing link exists
+        // between the producer HTTP transaction and this consumer transaction.
+        //
+        // TransportType.Kafka identifies the transport in the recorded span.
+        //
+        // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AcceptDistributedTraceHeaders
+        transaction.AcceptDistributedTraceHeaders(
+            result.Message.Headers,
+            (headers, key) =>
+            {
+                var header = headers?.FirstOrDefault(h => h.Key == key);
+                return header is null
+                    ? null!
+                    : new[] { Encoding.UTF8.GetString(header.GetValueBytes()) };
+            },
+            TransportType.Kafka);
+
+        // Name the transaction after the topic. Without the MessageBroker segment that
+        // Pattern 1 provides, an explicit name is the primary way to identify these
+        // transactions in the APM UI and NRQL queries.
+        // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetTransactionName
+        NewRelic.Api.Agent.NewRelic.SetTransactionName("Kafka", $"ProcessingOnly/{TopicName}");
+
+        // Add Kafka delivery metadata as custom attributes so they are queryable in NRQL.
+        // See: https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction.AddCustomAttribute
+        transaction
+            .AddCustomAttribute("kafka.topic", result.Topic)
+            .AddCustomAttribute("kafka.partition", result.Partition.Value)
+            .AddCustomAttribute("kafka.offset", result.Offset.Value)
+            .AddCustomAttribute("kafka.message.key", result.Message.Key ?? "(null)");
+
+        // Simulate processing work.
+        Thread.Sleep(Random.Shared.Next(250, 1000));
+
+        _logger.LogInformation(
+            "[ProcessingOnly] Processed message on {Topic} [{Partition}@{Offset}]: {Value}",
+            result.Topic, result.Partition.Value, result.Offset.Value, result.Message.Value);
+    }
+
+    public override void Dispose()
+    {
+        _consumer.Close();
+        _consumer.Dispose();
+        base.Dispose();
+    }
+}

--- a/kafka-custom-instrumentation/docker-compose.yml
+++ b/kafka-custom-instrumentation/docker-compose.yml
@@ -1,4 +1,6 @@
 services:
+  # Single-node Kafka broker running in KRaft mode (no ZooKeeper). Exposes port 9092
+  # for connections from the host and port 29092 for inter-container communication.
   kafka:
     image: confluentinc/cp-kafka:7.6.0
     hostname: kafka
@@ -18,6 +20,9 @@ services:
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qk"
 
+  # One-shot init container: waits for the broker to be ready, then pre-creates the
+  # two topics used by the example app. This avoids a race condition where the app
+  # starts before Kafka has finished initializing and auto-create-topics hasn't fired yet.
   kafka-init:
     image: confluentinc/cp-kafka:7.6.0
     depends_on:

--- a/kafka-custom-instrumentation/docker-compose.yml
+++ b/kafka-custom-instrumentation/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    hostname: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092"
+      KAFKA_PROCESS_ROLES: "broker,controller"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:29093"
+      KAFKA_LISTENERS: "PLAINTEXT://kafka:29092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
+      KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qk"
+
+  kafka-init:
+    image: confluentinc/cp-kafka:7.6.0
+    depends_on:
+      - kafka
+    entrypoint: ["/bin/sh", "-c"]
+    command: >
+      "cub kafka-ready -b kafka:29092 1 40 &&
+       kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic consume-to-complete-messages --partitions 1 --replication-factor 1 &&
+       kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic processing-only-messages --partitions 1 --replication-factor 1"

--- a/kafka-custom-instrumentation/kafka-custom-instrumentation.csproj
+++ b/kafka-custom-instrumentation/kafka-custom-instrumentation.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>default</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>KafkaCustomInstrumentation</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Use the latest version of the Confluent.Kafka package.
+      NOTE: For a production app, you should always reference a specific package version
+    -->
+    <PackageReference Include="Confluent.Kafka" Version="*" />
+    <!--
+      Use the latest version of the NewRelic.Agent package.
+      NOTE: For a production app, you should always reference a specific package version
+    -->
+    <PackageReference Include="NewRelic.Agent" Version="*" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="*" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This partially resolves this issue in the main agent repo: https://github.com/newrelic/newrelic-dotnet-agent/issues/3414

Add an example project showing the correct way to use dependency injection to add the agent API to a .NET application, as well as documenting examples of what not to do.

Edit: I mistakenly created this branch off of the Kafka example branch rather than `main`, so that PR will need to be merged first.
