### PR TITLE
Add OpenTelemetry-bridge AI monitoring example

### DIFF
--- a/NewRelicDotNetExamples.sln
+++ b/NewRelicDotNetExamples.sln
@@ -110,6 +110,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "api-dependency-injection", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api-dependency-injection", "api-dependency-injection\api-dependency-injection.csproj", "{033B6AFD-A0C0-4500-A93A-27E64468D556}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "otel-bridge-ai-monitoring", "otel-bridge-ai-monitoring\otel-bridge-ai-monitoring.csproj", "{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -324,6 +326,18 @@ Global
 		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Release|x64.Build.0 = Release|Any CPU
 		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Release|x86.ActiveCfg = Release|Any CPU
 		{033B6AFD-A0C0-4500-A93A-27E64468D556}.Release|x86.Build.0 = Release|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Debug|x64.Build.0 = Debug|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Debug|x86.Build.0 = Debug|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Release|x64.ActiveCfg = Release|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Release|x64.Build.0 = Release|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Release|x86.ActiveCfg = Release|Any CPU
+		{86C58437-4E23-4EC3-9A42-EF8258B6D0FC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/otel-bridge-ai-monitoring/Hubs/ChatHub.cs
+++ b/otel-bridge-ai-monitoring/Hubs/ChatHub.cs
@@ -17,7 +17,9 @@ namespace OtelBridgeAiMonitoring.Hubs;
 /// transaction for each WebSocket invocation (SignalR invocations are not HTTP requests, so
 /// they are not auto-instrumented). The GenAI spans produced by the OpenTelemetry-instrumented
 /// chat client nest under that transaction and are ingested by the agent's OpenTelemetry bridge
-/// as AI Monitoring data.
+/// as AI Monitoring data. The <c>[Transaction]</c> attribute is required because of SignalR's
+/// hosting model — not because of AI Monitoring; a controller action or minimal-API endpoint
+/// would be auto-instrumented without it.
 /// </summary>
 public class ChatHub : Hub
 {

--- a/otel-bridge-ai-monitoring/Hubs/ChatHub.cs
+++ b/otel-bridge-ai-monitoring/Hubs/ChatHub.cs
@@ -1,0 +1,90 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.AI;
+using NewRelic.Api.Agent;
+using OtelBridgeAiMonitoring.Services;
+
+namespace OtelBridgeAiMonitoring.Hubs;
+
+/// <summary>
+/// SignalR hub that relays browser chat messages to a language model through
+/// <see cref="IChatClient"/>. The underlying provider (Azure OpenAI or OpenAI) is chosen by
+/// configuration via <see cref="IChatClientFactory"/>.
+///
+/// Hub methods are decorated with <c>[Transaction]</c> so the New Relic agent starts a
+/// transaction for each WebSocket invocation (SignalR invocations are not HTTP requests, so
+/// they are not auto-instrumented). The GenAI spans produced by the OpenTelemetry-instrumented
+/// chat client nest under that transaction and are ingested by the agent's OpenTelemetry bridge
+/// as AI Monitoring data.
+/// </summary>
+public class ChatHub : Hub
+{
+    private readonly IChatClient _chatClient;
+    private readonly IChatClientFactory _chatClientFactory;
+
+    public ChatHub(IChatClient chatClient, IChatClientFactory chatClientFactory)
+    {
+        _chatClient = chatClient;
+        _chatClientFactory = chatClientFactory;
+    }
+
+    /// <summary>
+    /// Standard (non-streaming) completion. Sends the full response back to the caller once the
+    /// model finishes.
+    /// </summary>
+    [Transaction]
+    public async Task SendMessage(string prompt)
+    {
+        try
+        {
+            var result = await _chatClient.GetResponseAsync(prompt);
+            await Clients.Caller.SendAsync("ReceiveMessage", result.Text);
+        }
+        catch (Exception ex)
+        {
+            await Clients.Caller.SendAsync("ReceiveError", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Streaming completion. Forwards each chunk to the caller as the model produces it.
+    /// </summary>
+    [Transaction]
+    public async Task SendMessageStreaming(string prompt)
+    {
+        try
+        {
+            await foreach (var update in _chatClient.GetStreamingResponseAsync(prompt))
+            {
+                if (update.Text != null)
+                    await Clients.Caller.SendAsync("ReceiveChunk", update.Text);
+            }
+            await Clients.Caller.SendAsync("StreamComplete");
+        }
+        catch (Exception ex)
+        {
+            await Clients.Caller.SendAsync("ReceiveError", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Deliberately calls the model with an invalid API key to demonstrate how a failed GenAI
+    /// call is captured as an errored span. Useful for verifying error data appears in New Relic.
+    /// </summary>
+    [Transaction]
+    public async Task SendMessageFailure(string prompt)
+    {
+        try
+        {
+            using var errorClient = _chatClientFactory.Create(useBogusKey: true);
+            var result = await errorClient.GetResponseAsync(prompt);
+            await Clients.Caller.SendAsync("ReceiveMessage", result.Text);
+        }
+        catch (Exception ex)
+        {
+            await Clients.Caller.SendAsync("ReceiveError", $"Expected error: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/otel-bridge-ai-monitoring/Pages/Error.cshtml
+++ b/otel-bridge-ai-monitoring/Pages/Error.cshtml
@@ -1,0 +1,26 @@
+@page
+@model ErrorModel
+@{
+    ViewData["Title"] = "Error";
+}
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (Model.ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+    </p>
+}
+
+<h3>Development Mode</h3>
+<p>
+    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
+</p>
+<p>
+    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
+    It can result in displaying sensitive information from exceptions to end users.
+    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
+    and restarting the app.
+</p>

--- a/otel-bridge-ai-monitoring/Pages/Error.cshtml.cs
+++ b/otel-bridge-ai-monitoring/Pages/Error.cshtml.cs
@@ -1,0 +1,22 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace OtelBridgeAiMonitoring.Pages;
+
+[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+[IgnoreAntiforgeryToken]
+public class ErrorModel : PageModel
+{
+    public string? RequestId { get; set; }
+
+    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    public void OnGet()
+    {
+        RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+    }
+}

--- a/otel-bridge-ai-monitoring/Pages/Index.cshtml
+++ b/otel-bridge-ai-monitoring/Pages/Index.cshtml
@@ -1,0 +1,150 @@
+@page
+@model IndexModel
+@{
+    ViewData["Title"] = "AI Chat";
+}
+
+<h2>AI Chat</h2>
+<p class="text-muted small mb-3">
+    <code>Microsoft.Extensions.AI</code> + Azure OpenAI over a SignalR WebSocket &mdash;
+    instrumented with OpenTelemetry (source <code>OtelBridgeAiMonitoring</code>,
+    <code>EnableSensitiveData = true</code>) and ingested by the New Relic OpenTelemetry bridge.
+</p>
+
+<div id="chat-box" class="border rounded p-3 mb-3 bg-light" style="height: 420px; overflow-y: auto;">
+    <div id="messages"></div>
+</div>
+
+<div class="mb-2">
+    <textarea id="prompt-input" class="form-control" rows="2"
+              placeholder="Type a message and press Enter or click a send button..."
+              onkeydown="handleKey(event)"></textarea>
+</div>
+
+<div class="d-flex gap-2 align-items-center">
+    <button id="btn-standard" class="btn btn-primary" onclick="sendStandard()">Send (Standard)</button>
+    <button id="btn-streaming" class="btn btn-secondary" onclick="sendStreaming()">Send (Streaming)</button>
+    <button id="btn-failure" class="btn btn-outline-danger" onclick="sendFailure()">Test Error</button>
+    <span id="connection-status" class="ms-auto text-muted small">Connecting&hellip;</span>
+</div>
+
+@section Scripts {
+<script src="https://unpkg.com/@@microsoft/signalr@@8.0.7/dist/browser/signalr.min.js"></script>
+<script>
+    const connection = new signalR.HubConnectionBuilder()
+        .withUrl("/chathub")
+        .withAutomaticReconnect()
+        .build();
+
+    let streamingDiv = null;
+
+    connection.on("ReceiveMessage", text => {
+        appendMessage("ai", text);
+        setReady(true);
+    });
+
+    connection.on("ReceiveChunk", chunk => {
+        if (!streamingDiv) {
+            streamingDiv = appendMessage("ai", "");
+        }
+        streamingDiv.textContent += chunk;
+        scrollToBottom();
+    });
+
+    connection.on("StreamComplete", () => {
+        streamingDiv = null;
+        setReady(true);
+    });
+
+    connection.on("ReceiveError", error => {
+        appendMessage("error", error);
+        streamingDiv = null;
+        setReady(true);
+    });
+
+    connection.onreconnecting(() => setStatus("Reconnecting…", "text-warning"));
+    connection.onreconnected(() => setStatus("Connected", "text-success"));
+    connection.onclose(() => { setStatus("Disconnected", "text-danger"); setReady(false); });
+
+    connection.start()
+        .then(() => setStatus("Connected", "text-success"))
+        .catch(err => setStatus("Connection failed", "text-danger"));
+
+    function handleKey(e) {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            sendStandard();
+        }
+    }
+
+    function sendStandard() {
+        const prompt = getPrompt();
+        if (!prompt) return;
+        appendMessage("user", prompt);
+        setReady(false);
+        connection.invoke("SendMessage", prompt).catch(err => appendMessage("error", err.toString()));
+    }
+
+    function sendStreaming() {
+        const prompt = getPrompt();
+        if (!prompt) return;
+        appendMessage("user", prompt);
+        setReady(false);
+        connection.invoke("SendMessageStreaming", prompt).catch(err => appendMessage("error", err.toString()));
+    }
+
+    function sendFailure() {
+        const prompt = getPrompt();
+        if (!prompt) return;
+        appendMessage("user", "[failure test] " + prompt);
+        setReady(false);
+        connection.invoke("SendMessageFailure", prompt).catch(err => appendMessage("error", err.toString()));
+    }
+
+    function getPrompt() {
+        const el = document.getElementById("prompt-input");
+        const val = el.value.trim();
+        if (val) el.value = "";
+        return val;
+    }
+
+    function appendMessage(role, text) {
+        const wrap = document.createElement("div");
+        wrap.className = "mb-2 d-flex " + (role === "user" ? "justify-content-end" : "justify-content-start");
+
+        const bubble = document.createElement("div");
+        bubble.className = "rounded px-3 py-2 " + (
+            role === "user"  ? "bg-primary text-white" :
+            role === "error" ? "bg-danger text-white" :
+                               "bg-white border"
+        );
+        bubble.style.maxWidth = "80%";
+        bubble.style.whiteSpace = "pre-wrap";
+        bubble.style.wordBreak = "break-word";
+        bubble.textContent = text;
+
+        wrap.appendChild(bubble);
+        document.getElementById("messages").appendChild(wrap);
+        scrollToBottom();
+        return bubble;
+    }
+
+    function scrollToBottom() {
+        const box = document.getElementById("chat-box");
+        box.scrollTop = box.scrollHeight;
+    }
+
+    function setReady(enabled) {
+        ["btn-standard", "btn-streaming", "btn-failure"].forEach(id => {
+            document.getElementById(id).disabled = !enabled;
+        });
+        if (enabled) document.getElementById("prompt-input").focus();
+    }
+
+    function setStatus(text, cls) {
+        const el = document.getElementById("connection-status");
+        el.textContent = text;
+        el.className = "ms-auto small " + cls;
+    }
+</script>
+}

--- a/otel-bridge-ai-monitoring/Pages/Index.cshtml.cs
+++ b/otel-bridge-ai-monitoring/Pages/Index.cshtml.cs
@@ -1,0 +1,11 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace OtelBridgeAiMonitoring.Pages;
+
+public class IndexModel : PageModel
+{
+    public void OnGet() { }
+}

--- a/otel-bridge-ai-monitoring/Pages/Privacy.cshtml
+++ b/otel-bridge-ai-monitoring/Pages/Privacy.cshtml
@@ -1,0 +1,8 @@
+@page
+@model PrivacyModel
+@{
+    ViewData["Title"] = "Privacy Policy";
+}
+<h1>@ViewData["Title"]</h1>
+
+<p>Use this page to detail your site's privacy policy.</p>

--- a/otel-bridge-ai-monitoring/Pages/Privacy.cshtml.cs
+++ b/otel-bridge-ai-monitoring/Pages/Privacy.cshtml.cs
@@ -1,0 +1,13 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace OtelBridgeAiMonitoring.Pages;
+
+public class PrivacyModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/otel-bridge-ai-monitoring/Pages/Shared/_Layout.cshtml
+++ b/otel-bridge-ai-monitoring/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - OTel Bridge AI Monitoring</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/OtelBridgeAiMonitoring.styles.css" asp-append-version="true" />
+</head>
+<body>
+    <header>
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+            <div class="container">
+                <a class="navbar-brand" asp-area="" asp-page="/Index">OTel Bridge AI Monitoring</a>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
+                        aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                    <ul class="navbar-nav flex-grow-1">
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <div class="container">
+        <main role="main" class="pb-3">
+            @RenderBody()
+        </main>
+    </div>
+
+    <footer class="border-top footer text-muted">
+        <div class="container">
+            &copy; 2026 - OTel Bridge AI Monitoring - <a asp-area="" asp-page="/Privacy">Privacy</a>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+
+    @await RenderSectionAsync("Scripts", required: false)
+</body>
+</html>

--- a/otel-bridge-ai-monitoring/Pages/Shared/_Layout.cshtml.css
+++ b/otel-bridge-ai-monitoring/Pages/Shared/_Layout.cshtml.css
@@ -1,0 +1,48 @@
+/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
+for details on configuring this project to bundle and minify static web assets. */
+
+a.navbar-brand {
+  white-space: normal;
+  text-align: center;
+  word-break: break-all;
+}
+
+a {
+  color: #0077cc;
+}
+
+.btn-primary {
+  color: #fff;
+  background-color: #1b6ec2;
+  border-color: #1861ac;
+}
+
+.nav-pills .nav-link.active, .nav-pills .show > .nav-link {
+  color: #fff;
+  background-color: #1b6ec2;
+  border-color: #1861ac;
+}
+
+.border-top {
+  border-top: 1px solid #e5e5e5;
+}
+.border-bottom {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.box-shadow {
+  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
+}
+
+button.accept-policy {
+  font-size: 1rem;
+  line-height: inherit;
+}
+
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  white-space: nowrap;
+  line-height: 60px;
+}

--- a/otel-bridge-ai-monitoring/Pages/_ViewImports.cshtml
+++ b/otel-bridge-ai-monitoring/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using OtelBridgeAiMonitoring
+@namespace OtelBridgeAiMonitoring.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/otel-bridge-ai-monitoring/Pages/_ViewStart.cshtml
+++ b/otel-bridge-ai-monitoring/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/otel-bridge-ai-monitoring/Program.cs
+++ b/otel-bridge-ai-monitoring/Program.cs
@@ -1,0 +1,45 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.AI;
+using OtelBridgeAiMonitoring.Hubs;
+using OtelBridgeAiMonitoring.Services;
+using OpenTelemetry.Trace;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddSignalR();
+
+// The factory builds an IChatClient backed by either Azure OpenAI or OpenAI, selected by the
+// "AI:Provider" configuration value. Each client is wrapped with the Microsoft.Extensions.AI
+// OpenTelemetry instrumentation, which emits GenAI spans (model, token counts, and—when
+// EnableSensitiveData is true—prompt and completion content). The New Relic agent's
+// OpenTelemetry bridge ingests those spans and surfaces them as AI Monitoring data; no OTLP
+// exporter to New Relic is required.
+builder.Services.AddSingleton<IChatClientFactory, ChatClientFactory>();
+builder.Services.AddSingleton<IChatClient>(sp => sp.GetRequiredService<IChatClientFactory>().Create());
+
+// Register the GenAI ActivitySource with OpenTelemetry. The console exporter prints spans to
+// stdout for local visibility; the New Relic agent reads the spans independently via its bridge.
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource(ChatClientFactory.ActivitySourceName)
+        .AddConsoleExporter());
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseRouting();
+app.UseAuthorization();
+app.MapStaticAssets();
+app.MapRazorPages().WithStaticAssets();
+app.MapHub<ChatHub>("/chathub");
+
+app.Run();

--- a/otel-bridge-ai-monitoring/README.md
+++ b/otel-bridge-ai-monitoring/README.md
@@ -24,7 +24,7 @@ Browser ──WebSocket──► ChatHub.SendMessage  [Transaction]
 
 2. **The New Relic agent reads those spans via its OpenTelemetry bridge.** When the bridge is enabled, the agent listens to the application's `ActivitySource`s directly, parses the `gen_ai.*` tags, and produces New Relic AI Monitoring events (`LlmChatCompletionSummary`, `LlmChatCompletionMessage`, etc.). The application does **not** send OTLP to New Relic — the agent does the export. The bundled console exporter exists only so you can see the spans locally.
 
-3. **Hub methods carry the `[Transaction]` attribute.** SignalR hub invocations arrive over a WebSocket and are not HTTP requests, so they are not auto-instrumented. `[Transaction]` (from `NewRelic.Agent.Api`) starts a New Relic transaction for each call so the GenAI spans have a parent transaction to nest under.
+3. **Hub methods carry the `[Transaction]` attribute.** SignalR hub invocations arrive over a WebSocket and are not HTTP requests, so they are not auto-instrumented. `[Transaction]` (from `NewRelic.Agent.Api`) starts a New Relic transaction for each call so the GenAI spans have a parent transaction to nest under. This is a consequence of SignalR's hosting model, not an AI Monitoring requirement — in a controller-based or minimal-API web app, the agent auto-instruments each HTTP request and no `[Transaction]` attribute is needed.
 
 ## Key Concepts Demonstrated
 
@@ -61,9 +61,11 @@ It also depends on three agent settings. **Two of them are off by default**, so 
 
 See the [.NET agent AI Monitoring configuration docs](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#ai_monitoring).
 
-### Why the `[Transaction]` Attribute Is Needed
+### Why the `[Transaction]` Attribute Is Needed Here
 
 The agent's built-in ASP.NET Core instrumentation automatically creates a transaction for each incoming HTTP request. SignalR hub method invocations, however, arrive over a persistent WebSocket connection and are not individual HTTP requests, so auto-instrumentation does not apply. The `[Transaction]` attribute on each `ChatHub` method ensures the agent creates a transaction for the call, giving the GenAI spans a parent transaction to nest under.
+
+In short, the attribute here addresses *how SignalR is hosted*, and has nothing to do with AI Monitoring specifically. If this example exposed its model calls through a controller action or minimal-API endpoint instead of a SignalR hub, the agent's automatic ASP.NET Core instrumentation would create the transaction and the attribute would be unnecessary.
 
 ## What the App Does
 

--- a/otel-bridge-ai-monitoring/README.md
+++ b/otel-bridge-ai-monitoring/README.md
@@ -1,0 +1,244 @@
+# New Relic .NET Agent — AI Monitoring via the OpenTelemetry Bridge Example
+
+This example demonstrates how the New Relic .NET agent captures **AI Monitoring** data for [`Microsoft.Extensions.AI`](https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai) through its **OpenTelemetry bridge** (sometimes called the "hybrid agent"). A Razor Pages chat application calls a language model, the AI client is instrumented with OpenTelemetry, and the agent ingests the resulting GenAI spans as AI Monitoring events — no OTLP exporter pointed at New Relic is required. The underlying model provider is selectable at runtime: the same instrumentation works with **Azure OpenAI** or **OpenAI**.
+
+## How It Works
+
+```
+Browser ──WebSocket──► ChatHub.SendMessage  [Transaction]
+                             │
+                             ▼
+                IChatClient (Microsoft.Extensions.AI)
+                             │  .UseOpenTelemetry(EnableSensitiveData = true)
+                             ▼
+                ActivitySource "OtelBridgeAiMonitoring"  ──► GenAI spans (gen_ai.* tags)
+                             │
+                             ▼
+        New Relic .NET agent — OpenTelemetry bridge + AI Monitoring
+                             │
+                             ▼
+                     New Relic ── APM + AI Monitoring
+```
+
+1. **The AI client is instrumented with OpenTelemetry.** `ChatClientFactory` wraps the provider's `IChatClient` with `.UseOpenTelemetry(...)`. The Microsoft.Extensions.AI instrumentation emits [GenAI semantic-convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) spans (model name, token usage, and — because `EnableSensitiveData = true` — the prompt and completion text) to a custom `ActivitySource`.
+
+2. **The New Relic agent reads those spans via its OpenTelemetry bridge.** When the bridge is enabled, the agent listens to the application's `ActivitySource`s directly, parses the `gen_ai.*` tags, and produces New Relic AI Monitoring events (`LlmChatCompletionSummary`, `LlmChatCompletionMessage`, etc.). The application does **not** send OTLP to New Relic — the agent does the export. The bundled console exporter exists only so you can see the spans locally.
+
+3. **Hub methods carry the `[Transaction]` attribute.** SignalR hub invocations arrive over a WebSocket and are not HTTP requests, so they are not auto-instrumented. `[Transaction]` (from `NewRelic.Agent.Api`) starts a New Relic transaction for each call so the GenAI spans have a parent transaction to nest under.
+
+## Key Concepts Demonstrated
+
+### Why the OpenTelemetry Bridge
+
+`Microsoft.Extensions.AI` is a provider-agnostic abstraction over many model providers. Rather than instrument each provider SDK natively, the agent consumes the standardized GenAI OpenTelemetry spans that `Microsoft.Extensions.AI` already emits. Any provider you plug in behind `IChatClient` — Azure OpenAI and OpenAI are shown here — is captured the same way.
+
+### Choosing a Provider: Azure OpenAI or OpenAI
+
+The provider is selected by the `AI:Provider` configuration value. `ChatClientFactory` reads it and builds the appropriate client:
+
+| `AI:Provider` | Backend | Client type | Settings used |
+|---------------|---------|-------------|---------------|
+| `azure` (default) | Azure OpenAI | `AzureOpenAIClient` (`Azure.AI.OpenAI`) | `AzureOpenAI:Endpoint`, `AzureOpenAI:ApiKey`, `AzureOpenAI:DeploymentName` |
+| `openai` | OpenAI | `OpenAIClient` (`OpenAI`) | `OpenAI:ApiKey`, `OpenAI:Model` |
+
+Both `AzureOpenAIClient.GetChatClient(...)` and `OpenAIClient.GetChatClient(...)` return the same `OpenAI.Chat.ChatClient` type, so a single code path in `ChatClientFactory` instruments either provider identically. The agent's GenAI parsing requires the `OpenAI` package version **2.8.0 or later** (and `Microsoft.Extensions.AI` / `Microsoft.Extensions.AI.OpenAI` **10.3.0 or later**).
+
+### The Custom ActivitySource Name
+
+The example emits spans to a custom, application-owned `ActivitySource` named `OtelBridgeAiMonitoring`. The bridge listens to custom sources by default, so no include list is needed. Do **not** reuse the OpenAI SDK's own built-in source `OpenAI.ChatClient` — the agent excludes that source by default to avoid duplicate spans.
+
+### Required Agent Settings
+
+AI Monitoring for `Microsoft.Extensions.AI` through the OpenTelemetry bridge requires New Relic .NET agent **version 10.50.0 or later**.
+
+It also depends on three agent settings. **Two of them are off by default**, so AI Monitoring will not work until you turn them on:
+
+| Setting | Default | Required value | Environment variable | `newrelic.config` |
+|---------|---------|----------------|----------------------|-------------------|
+| AI Monitoring | **off** | on | `NEW_RELIC_AI_MONITORING_ENABLED=1` | `<aiMonitoring enabled="true">` |
+| OpenTelemetry bridge | **off** | on | `NEW_RELIC_OPENTELEMETRY_ENABLED=1` | `<openTelemetry enabled="true">` |
+| AI Monitoring content recording | on | on (to see prompt/response text) | `NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=1` | `<recordContent enabled="true">` (under `aiMonitoring`) |
+
+See the [.NET agent AI Monitoring configuration docs](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#ai_monitoring).
+
+### Why the `[Transaction]` Attribute Is Needed
+
+The agent's built-in ASP.NET Core instrumentation automatically creates a transaction for each incoming HTTP request. SignalR hub method invocations, however, arrive over a persistent WebSocket connection and are not individual HTTP requests, so auto-instrumentation does not apply. The `[Transaction]` attribute on each `ChatHub` method ensures the agent creates a transaction for the call, giving the GenAI spans a parent transaction to nest under.
+
+## What the App Does
+
+A minimal chat UI (one Razor page over a SignalR hub) with three buttons, each exercising a different path through the instrumented client:
+
+| Button | Hub method | Demonstrates |
+|--------|------------|--------------|
+| **Send (Standard)** | `SendMessage` | A standard, non-streaming completion. |
+| **Send (Streaming)** | `SendMessageStreaming` | A streaming completion (`GetStreamingResponseAsync`). |
+| **Test Error** | `SendMessageFailure` | A call made with a deliberately invalid API key, so you can confirm errored GenAI calls appear in New Relic. |
+
+## How to Run
+
+### Prerequisites
+
+- .NET 10 SDK
+- A New Relic account with a license key
+- New Relic .NET agent **version 10.50.0 or later** (the release that added AI Monitoring for `Microsoft.Extensions.AI` via the OpenTelemetry bridge)
+- A model provider account: an Azure OpenAI resource with a deployed chat model, or an OpenAI API key
+
+### NuGet Packages
+
+This example references the following NuGet packages:
+
+- **`NewRelic.Agent`** — Bundles the agent runtime files (profiler, configuration, extensions) into the build output directory. This is one of several ways to install the agent; alternatives include OS package managers and container-based installation.
+- **`NewRelic.Agent.Api`** — Provides the `NewRelic.Api.Agent` namespace used in this example (the `[Transaction]` attribute on the hub methods). This package is required for any application that calls the agent API directly.
+- **`Microsoft.Extensions.AI`**, **`Microsoft.Extensions.AI.OpenAI`**, **`Azure.AI.OpenAI`**, **`OpenAI`** — The GenAI client being instrumented. The versions referenced (`Azure.AI.OpenAI` `2.8.0-beta.1` and `OpenAI` `2.8.0`) are the combination verified by the agent's integration tests.
+- **`OpenTelemetry.Extensions.Hosting`**, **`OpenTelemetry.Exporter.Console`** — Register the OpenTelemetry tracer provider and print spans to the console for local visibility. The console exporter is **not** required for New Relic ingestion.
+
+### Configure the Provider
+
+Select the provider and supply its credentials. The application reads these as standard [.NET configuration](https://learn.microsoft.com/aspnet/core/fundamentals/configuration/), so you can provide them either as **user secrets** or as **environment variables** — either method is acceptable, and both override the placeholder values in `appsettings.json`. (Editing `appsettings.json` directly also works but is discouraged for credentials.)
+
+The settings used per provider:
+
+| Config key | Environment variable | Notes |
+|------------|----------------------|-------|
+| `AI:Provider` | `AI__Provider` | `azure` (default) or `openai` |
+| `AzureOpenAI:Endpoint` | `AzureOpenAI__Endpoint` | Azure only |
+| `AzureOpenAI:ApiKey` | `AzureOpenAI__ApiKey` | Azure only |
+| `AzureOpenAI:DeploymentName` | `AzureOpenAI__DeploymentName` | Azure only; defaults to `gpt-4o-mini` |
+| `OpenAI:ApiKey` | `OpenAI__ApiKey` | OpenAI only |
+| `OpenAI:Model` | `OpenAI__Model` | OpenAI only; defaults to `gpt-4o-mini` |
+
+Environment-variable names replace the `:` separator with a double underscore (`__`), per the .NET [environment variables configuration provider](https://learn.microsoft.com/aspnet/core/fundamentals/configuration/#environment-variables).
+
+#### Option A — user secrets
+
+**Azure OpenAI:**
+
+```bash
+dotnet user-secrets init
+dotnet user-secrets set "AI:Provider" "azure"
+dotnet user-secrets set "AzureOpenAI:Endpoint" "https://your-resource.openai.azure.com/"
+dotnet user-secrets set "AzureOpenAI:ApiKey" "<your-azure-openai-key>"
+dotnet user-secrets set "AzureOpenAI:DeploymentName" "gpt-4o-mini"
+```
+
+**OpenAI:**
+
+```bash
+dotnet user-secrets init
+dotnet user-secrets set "AI:Provider" "openai"
+dotnet user-secrets set "OpenAI:ApiKey" "<your-openai-key>"
+dotnet user-secrets set "OpenAI:Model" "gpt-4o-mini"
+```
+
+#### Option B — environment variables
+
+**Azure OpenAI — Windows (PowerShell):**
+
+```powershell
+$env:AI__Provider="azure"
+$env:AzureOpenAI__Endpoint="https://your-resource.openai.azure.com/"
+$env:AzureOpenAI__ApiKey="<your-azure-openai-key>"
+$env:AzureOpenAI__DeploymentName="gpt-4o-mini"
+```
+
+**Azure OpenAI — Linux / macOS (bash):**
+
+```bash
+export AI__Provider="azure"
+export AzureOpenAI__Endpoint="https://your-resource.openai.azure.com/"
+export AzureOpenAI__ApiKey="<your-azure-openai-key>"
+export AzureOpenAI__DeploymentName="gpt-4o-mini"
+```
+
+**OpenAI — Windows (PowerShell):**
+
+```powershell
+$env:AI__Provider="openai"
+$env:OpenAI__ApiKey="<your-openai-key>"
+$env:OpenAI__Model="gpt-4o-mini"
+```
+
+**OpenAI — Linux / macOS (bash):**
+
+```bash
+export AI__Provider="openai"
+export OpenAI__ApiKey="<your-openai-key>"
+export OpenAI__Model="gpt-4o-mini"
+```
+
+Set these in the same shell session you use to run the app, alongside the agent variables below.
+
+### Run the Application
+
+This example uses the `NewRelic.Agent` NuGet package, which places the agent files under the build output directory. You must set several [environment variables](https://docs.newrelic.com/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/) to enable the .NET CLR profiler, the OpenTelemetry bridge, and AI Monitoring.
+
+**Windows (PowerShell):**
+
+```powershell
+# Build first so the agent files are in the output directory
+dotnet build -c Release
+
+# Set the required environment variables for the .NET agent
+$env:CORECLR_ENABLE_PROFILING=1
+$env:CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+$env:CORECLR_PROFILER_PATH="$PWD\bin\Release\net10.0\newrelic\NewRelic.Profiler.dll"
+$env:CORECLR_NEWRELIC_HOME="$PWD\bin\Release\net10.0\newrelic"
+$env:NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+$env:NEW_RELIC_APP_NAME="otel-bridge-ai-monitoring-example"
+
+# Enable AI Monitoring and the OpenTelemetry bridge (both OFF by default)
+$env:NEW_RELIC_AI_MONITORING_ENABLED=1
+$env:NEW_RELIC_OPENTELEMETRY_ENABLED=1
+$env:NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=1
+
+# Run the application
+dotnet run -c Release --no-build
+```
+
+**Linux / macOS (bash):**
+
+```bash
+# Build first so the agent files are in the output directory
+dotnet build -c Release
+
+# Set the required environment variables for the .NET agent
+export CORECLR_ENABLE_PROFILING=1
+export CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+export CORECLR_PROFILER_PATH="$PWD/bin/Release/net10.0/newrelic/libNewRelicProfiler.so"
+export CORECLR_NEWRELIC_HOME="$PWD/bin/Release/net10.0/newrelic"
+export NEW_RELIC_LICENSE_KEY="<your-new-relic-license-key>"
+export NEW_RELIC_APP_NAME="otel-bridge-ai-monitoring-example"
+
+# Enable AI Monitoring and the OpenTelemetry bridge (both OFF by default)
+export NEW_RELIC_AI_MONITORING_ENABLED=1
+export NEW_RELIC_OPENTELEMETRY_ENABLED=1
+export NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=1
+
+# Run the application
+dotnet run -c Release --no-build
+```
+
+Then open the app (the console prints the URL, e.g. `https://localhost:7102`), type a prompt, and use the three buttons.
+
+| Variable | Purpose |
+|----------|---------|
+| `CORECLR_ENABLE_PROFILING` | Enables the .NET CLR profiler (must be `1`) |
+| `CORECLR_PROFILER` | The CLSID of the New Relic profiler |
+| `CORECLR_PROFILER_PATH` | Path to the profiler native library (`NewRelic.Profiler.dll` on Windows, `libNewRelicProfiler.so` on Linux) |
+| `CORECLR_NEWRELIC_HOME` | Path to the directory containing the agent configuration and extensions |
+| `NEW_RELIC_LICENSE_KEY` | Your New Relic license key |
+| `NEW_RELIC_APP_NAME` | The application name as it will appear in New Relic |
+| `NEW_RELIC_AI_MONITORING_ENABLED` | Enables AI Monitoring. Off by default; required for this example |
+| `NEW_RELIC_OPENTELEMETRY_ENABLED` | Enables the OpenTelemetry bridge. Off by default; required for this example |
+| `NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED` | Controls whether prompt/response content is recorded. On by default; set to `0` to suppress message content |
+
+## What to Look for in New Relic
+
+After exercising the buttons a few times:
+
+- **APM → your app → Transactions** shows transactions named for the `ChatHub` methods (`SendMessage`, `SendMessageStreaming`, `SendMessageFailure`).
+- **AI Monitoring** surfaces the GenAI calls, including model name, token counts, and — with content recording enabled — prompt and response content.
+- The **Test Error** button produces errored GenAI calls you can inspect in **Errors Inbox** and AI Monitoring.
+
+> **Note on sensitive data:** `EnableSensitiveData = true` (in the app) puts prompt and completion text on the spans, and `aiMonitoring.recordContent` (in the agent) controls whether the agent records it. Disable either if message content must not leave your environment.

--- a/otel-bridge-ai-monitoring/Services/ChatClientFactory.cs
+++ b/otel-bridge-ai-monitoring/Services/ChatClientFactory.cs
@@ -1,0 +1,90 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.ClientModel;
+using Azure.AI.OpenAI;
+using Microsoft.Extensions.AI;
+using OpenAI;
+
+namespace OtelBridgeAiMonitoring.Services;
+
+/// <summary>
+/// Creates OpenTelemetry-instrumented <see cref="IChatClient"/> instances for Azure OpenAI or
+/// OpenAI. The choice is driven by the "AI:Provider" configuration value ("azure" or "openai").
+///
+/// Both <c>AzureOpenAIClient</c> and <c>OpenAIClient</c> expose <c>GetChatClient</c>, which
+/// returns the same <see cref="OpenAI.Chat.ChatClient"/> type, so a single
+/// <see cref="WrapWithOpenTelemetry"/> path instruments either provider identically. The
+/// instrumentation emits GenAI semantic-convention spans that the New Relic agent's
+/// OpenTelemetry bridge converts into AI Monitoring data.
+/// </summary>
+public class ChatClientFactory : IChatClientFactory
+{
+    /// <summary>
+    /// ActivitySource name the Microsoft.Extensions.AI OpenTelemetry instrumentation emits to.
+    /// This is a custom (application-owned) name, so the New Relic OpenTelemetry bridge listens
+    /// to it by default. Do not reuse the OpenAI SDK's built-in "OpenAI.ChatClient" source — the
+    /// agent excludes that one by default.
+    /// </summary>
+    public const string ActivitySourceName = "OtelBridgeAiMonitoring";
+
+    private const string BogusKeySuffix = "-bogus-key-for-testing";
+
+    private readonly IConfiguration _config;
+
+    public ChatClientFactory(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public IChatClient Create(bool useBogusKey = false)
+    {
+        var provider = _config["AI:Provider"] ?? "azure";
+
+        var chatClient = provider.Equals("openai", StringComparison.OrdinalIgnoreCase)
+            ? CreateOpenAIChatClient(useBogusKey)
+            : CreateAzureChatClient(useBogusKey);
+
+        return WrapWithOpenTelemetry(chatClient);
+    }
+
+    private OpenAI.Chat.ChatClient CreateAzureChatClient(bool useBogusKey)
+    {
+        var endpoint = _config["AzureOpenAI:Endpoint"]
+            ?? throw new InvalidOperationException("AzureOpenAI:Endpoint is required when AI:Provider is 'azure'");
+        var apiKey = _config["AzureOpenAI:ApiKey"]
+            ?? throw new InvalidOperationException("AzureOpenAI:ApiKey is required when AI:Provider is 'azure'");
+        var deploymentName = _config["AzureOpenAI:DeploymentName"] ?? "gpt-4o-mini";
+
+        if (useBogusKey)
+            apiKey += BogusKeySuffix;
+
+        var azureClient = new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey));
+        return azureClient.GetChatClient(deploymentName);
+    }
+
+    private OpenAI.Chat.ChatClient CreateOpenAIChatClient(bool useBogusKey)
+    {
+        var apiKey = _config["OpenAI:ApiKey"]
+            ?? throw new InvalidOperationException("OpenAI:ApiKey is required when AI:Provider is 'openai'");
+        var model = _config["OpenAI:Model"] ?? "gpt-4o-mini";
+
+        if (useBogusKey)
+            apiKey += BogusKeySuffix;
+
+        var openAIClient = new OpenAIClient(new ApiKeyCredential(apiKey));
+        return openAIClient.GetChatClient(model);
+    }
+
+    private static IChatClient WrapWithOpenTelemetry(OpenAI.Chat.ChatClient chatClient)
+    {
+        return new ChatClientBuilder(chatClient.AsIChatClient())
+            .UseOpenTelemetry(sourceName: ActivitySourceName, configure: options =>
+            {
+                // Captures prompt and completion content on the spans. The New Relic agent only
+                // records that content when aiMonitoring.recordContent is also enabled.
+                options.EnableSensitiveData = true;
+            })
+            .Build();
+    }
+}

--- a/otel-bridge-ai-monitoring/Services/IChatClientFactory.cs
+++ b/otel-bridge-ai-monitoring/Services/IChatClientFactory.cs
@@ -1,0 +1,22 @@
+// Copyright 2023 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.AI;
+
+namespace OtelBridgeAiMonitoring.Services;
+
+/// <summary>
+/// Builds OpenTelemetry-instrumented <see cref="IChatClient"/> instances backed by either
+/// Azure OpenAI or OpenAI, selected by configuration.
+/// </summary>
+public interface IChatClientFactory
+{
+    /// <summary>
+    /// Creates an instrumented chat client for the configured provider.
+    /// </summary>
+    /// <param name="useBogusKey">
+    /// When true, an intentionally invalid API key is used so the call fails — useful for
+    /// demonstrating how errored GenAI calls are reported.
+    /// </param>
+    IChatClient Create(bool useBogusKey = false);
+}

--- a/otel-bridge-ai-monitoring/appsettings.Development.json
+++ b/otel-bridge-ai-monitoring/appsettings.Development.json
@@ -1,0 +1,25 @@
+{
+  "DetailedErrors": true,
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Extensions.AI": "Debug"
+    }
+  },
+
+  "AI": {
+    "Provider": "azure"
+  },
+
+  "AzureOpenAI": {
+    "Endpoint": "https://your-resource.openai.azure.com/",
+    "ApiKey": "your-azure-openai-key-here",
+    "DeploymentName": "gpt-4o-mini"
+  },
+
+  "OpenAI": {
+    "ApiKey": "your-openai-key-here",
+    "Model": "gpt-4o-mini"
+  }
+}

--- a/otel-bridge-ai-monitoring/appsettings.json
+++ b/otel-bridge-ai-monitoring/appsettings.json
@@ -1,0 +1,25 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+
+  "//AI": "Provider selects which backend to use: 'azure' (Azure OpenAI) or 'openai' (OpenAI).",
+  "AI": {
+    "Provider": "azure"
+  },
+
+  "AzureOpenAI": {
+    "Endpoint": "https://your-resource.openai.azure.com/",
+    "ApiKey": "your-azure-openai-key-here",
+    "DeploymentName": "gpt-4o-mini"
+  },
+
+  "OpenAI": {
+    "ApiKey": "your-openai-key-here",
+    "Model": "gpt-4o-mini"
+  }
+}

--- a/otel-bridge-ai-monitoring/otel-bridge-ai-monitoring.csproj
+++ b/otel-bridge-ai-monitoring/otel-bridge-ai-monitoring.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>OtelBridgeAiMonitoring</RootNamespace>
+    <AssemblyName>OtelBridgeAiMonitoring</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Microsoft.Extensions.AI is the provider-agnostic abstraction being instrumented.
+         The underlying client can be Azure OpenAI (Azure.AI.OpenAI) or OpenAI (OpenAI);
+         the example selects between them at runtime via the "AI:Provider" setting.
+         Versions match the combination verified by the agent's integration tests:
+         OpenAI 2.8.0+ is required by the agent's GenAI bridge. -->
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
+    <PackageReference Include="OpenAI" Version="2.8.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.3.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
+
+    <!-- OpenTelemetry: produces the GenAI spans the New Relic agent ingests via its OTel bridge.
+         The console exporter is included only so you can see the spans locally; it is not
+         required for New Relic ingestion. -->
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+
+    <!-- NewRelic.Agent bundles the agent runtime (profiler, config, extensions) into the build
+         output so the example can be run end-to-end with the CLR profiler env vars below.
+         NewRelic.Agent.Api provides the [Transaction] attribute used in ChatHub. -->
+    <PackageReference Include="NewRelic.Agent" Version="*" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="*" />
+  </ItemGroup>
+
+</Project>

--- a/otel-bridge-ai-monitoring/wwwroot/css/site.css
+++ b/otel-bridge-ai-monitoring/wwwroot/css/site.css
@@ -1,0 +1,31 @@
+html {
+  font-size: 14px;
+}
+
+@media (min-width: 768px) {
+  html {
+    font-size: 16px;
+  }
+}
+
+.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
+  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
+}
+
+html {
+  position: relative;
+  min-height: 100%;
+}
+
+body {
+  margin-bottom: 60px;
+}
+
+.form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
+  color: var(--bs-secondary-color);
+  text-align: end;
+}
+
+.form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
+  text-align: start;
+}

--- a/otel-bridge-ai-monitoring/wwwroot/js/site.js
+++ b/otel-bridge-ai-monitoring/wwwroot/js/site.js
@@ -1,0 +1,4 @@
+// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
+// for details on configuring this project to bundle and minify static web assets.
+
+// Write your JavaScript code.


### PR DESCRIPTION
Adds a new example, `otel-bridge-ai-monitoring`, demonstrating New Relic AI Monitoring of `Microsoft.Extensions.AI` via the .NET agent's OpenTelemetry bridge ("hybrid agent").

## What it shows
- A Razor Pages + SignalR chat app whose `IChatClient` is instrumented with `.UseOpenTelemetry(EnableSensitiveData = true)`. The agent ingests the GenAI spans as AI Monitoring data — no OTLP export to New Relic required.
- Runtime provider selection via `AI:Provider`: **Azure OpenAI** or **OpenAI**, through a single `ChatClientFactory` code path.
- `[Transaction]` on the SignalR hub methods (WebSocket invocations aren't auto-instrumented).
- Three UI paths: standard completion, streaming completion, and a deliberate-error case.

## Requirements documented
- .NET agent **10.50.0+** (the release that added `Microsoft.Extensions.AI` bridge support).
- Agent settings: `NEW_RELIC_AI_MONITORING_ENABLED` and `NEW_RELIC_OPENTELEMETRY_ENABLED` (both off by default), plus content recording.
- Package versions matching the agent's integration tests (`Azure.AI.OpenAI` 2.8.0-beta.1, `OpenAI` 2.8.0).

README follows the structure of the existing API examples and documents both user-secrets and environment-variable configuration.

## Verification
Built against `FullAgent`-equivalent NuGet agent (10.51.1) and run locally with Azure OpenAI: confirmed a real chat completion, the GenAI OTel span (model/tokens/messages), agent attach, and collector connection.

Project added to `NewRelicDotNetExamples.sln`.