### PR TITLE
Remove deprecated .WithOpenApi() calls

### DIFF
--- a/ignore-errors/Program.cs
+++ b/ignore-errors/Program.cs
@@ -36,8 +36,7 @@ app.MapGet("/weatherforecast", () =>
         .ToArray();
     return forecast;
 })
-.WithName("GetWeatherForecast")
-.WithOpenApi();
+.WithName("GetWeatherForecast");
 
 // An endpoint to return an error status code for the purposes of testing the agent's ignored and expected errors features
 app.MapGet("/throwerror", () =>
@@ -45,8 +44,7 @@ app.MapGet("/throwerror", () =>
     return Results.StatusCode(422);
     
 })
-.WithName("ThrowError")
-.WithOpenApi();
+.WithName("ThrowError");
 
 app.Run();
 


### PR DESCRIPTION
## Summary

The `Microsoft.AspNetCore.OpenApi` 10.0.9 bump (merged via dependabot) deprecated the minimal-API `.WithOpenApi()` extension method, producing `ASPDEPR002` build warnings in `ignore-errors/Program.cs`:

```
Warning ASPDEPR002 'OpenApiEndpointConventionBuilderExtensions.WithOpenApi<TBuilder>(TBuilder)' is obsolete:
  'WithOpenApi is deprecated and will be removed in a future release. https://aka.ms/aspnet/deprecate/002'
  ignore-errors/Program.cs(40,1)
  ignore-errors/Program.cs(49,1)
```

## Fix

Per the ASP.NET Core deprecation guidance (https://aka.ms/aspnet/deprecate/002), `.WithOpenApi()` should be removed. The `ignore-errors` example uses Swashbuckle for its Swagger UI, and both calls carried no per-endpoint customization (no lambda argument), so they are simply removed. Swashbuckle discovers the endpoints on its own; no replacement API is needed.

## Verification

- `dotnet build` on the full solution: 0 warnings, 0 errors.